### PR TITLE
Add pubsub io

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.6.3"]
                  [clj-stacktrace "0.2.8"]
-                 [com.google.cloud.dataflow/google-cloud-dataflow-java-sdk-all "1.6.0"]
+                 [com.google.cloud.dataflow/google-cloud-dataflow-java-sdk-all "1.6.1"]
                  [com.taoensso/nippy "2.12.1"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/math.combinatorics "0.1.3"]

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
   :profiles {:dev {:dependencies [[junit/junit "4.12"]
                                   [me.raynes/fs "1.4.6"]
                                   [org.hamcrest/hamcrest-all "1.3"]]
-                   :aot [datasplash.api-test datasplash.examples clj-time.core]
+                   :aot [clojure.tools.logging.impl datasplash.api-test datasplash.examples clj-time.core]
                    :codox {:namespaces [datasplash.api datasplash.bq datasplash.datastore]
                            :source-uri "https://github.com/ngrunwald/datasplash/blob/master/{filepath}#L{line}"
                            :metadata {:doc/format :markdown}}

--- a/src/datasplash/pubsub.clj
+++ b/src/datasplash/pubsub.clj
@@ -6,10 +6,10 @@
 
 (defn read-from-pubsub
   "Create an unbounded PCollection from a pubsub stream"
-  [topic options p]
+  [subscription options p]
   (-> p
       (cond-> (instance? Pipeline p) (PBegin/in))
-      (apply-transform (PubsubIO$Read/subscription topic) {} options)))
+      (apply-transform (PubsubIO$Read/subscription subscription) {} options)))
 
 (defn write-to-pubsub
   "Write the contents of an unbounded PCollection to to a pubsub stream"

--- a/src/datasplash/pubsub.clj
+++ b/src/datasplash/pubsub.clj
@@ -1,0 +1,42 @@
+(ns datasplash.pubsub
+  (:require [datasplash.core :refer :all])
+  (:import (com.google.cloud.dataflow.sdk.io PubsubIO$Read PubsubIO$Write)
+           (com.google.cloud.dataflow.sdk.values PBegin)
+           (com.google.cloud.dataflow.sdk Pipeline)))
+
+(defn read-from-pubsub
+  "Create an unbounded PCollection from a pubsub stream"
+  [topic options p]
+  (-> p
+      (cond-> (instance? Pipeline p) (PBegin/in))
+      (apply-transform (PubsubIO$Read/subscription topic) {} options)))
+
+(defn write-to-pubsub
+  "Write the contents of an unbounded PCollection to to a pubsub stream"
+  [topic options pcoll]
+  (-> pcoll
+      (apply-transform (PubsubIO$Write/topic topic) {} options)))
+
+; Example
+;(def read-subscription "projects/my-project/subscriptions/my-subscription")
+;(def write-transformed-topic "projects/my-project/topics/my-transformed-topic")
+;(def read-transformed-subscription "projects/my-project/subscriptions/my-transformed-subscription")
+;
+;(defn stream-interactions-from-pubsub
+;  [pipeline]
+;  (->> pipeline
+;       (read-from-pubsub read-subscription {:name "read-interactions-from-pubsub"})
+;       (ds/map (fn [message]
+;                 (do
+;                   (log/info (str "Got message:\n" message))
+;                   message)) {:name "log-message"})
+;       (write-to-pubsub write-transformed-topic {:name "write-forwarded-interactions-to-pubsub"})))
+;
+;(defn stream-forwarded-interactions-from-pubsub
+;  [pipeline]
+;  (->> pipeline
+;       (read-from-pubsub read-transformed-subscription {:name "read-transformed-interactions-from-pubsub"})
+;       (ds/map (fn [message]
+;                 (do
+;                   (log/info (str "Got transformed message:\n" message))
+;                   message)) {:name "log-transformed-message"})))

--- a/src/datasplash/pubsub.clj
+++ b/src/datasplash/pubsub.clj
@@ -16,27 +16,3 @@
   [topic options pcoll]
   (-> pcoll
       (apply-transform (PubsubIO$Write/topic topic) {} options)))
-
-; Example
-;(def read-subscription "projects/my-project/subscriptions/my-subscription")
-;(def write-transformed-topic "projects/my-project/topics/my-transformed-topic")
-;(def read-transformed-subscription "projects/my-project/subscriptions/my-transformed-subscription")
-;
-;(defn stream-interactions-from-pubsub
-;  [pipeline]
-;  (->> pipeline
-;       (read-from-pubsub read-subscription {:name "read-interactions-from-pubsub"})
-;       (ds/map (fn [message]
-;                 (do
-;                   (log/info (str "Got message:\n" message))
-;                   message)) {:name "log-message"})
-;       (write-to-pubsub write-transformed-topic {:name "write-forwarded-interactions-to-pubsub"})))
-;
-;(defn stream-forwarded-interactions-from-pubsub
-;  [pipeline]
-;  (->> pipeline
-;       (read-from-pubsub read-transformed-subscription {:name "read-transformed-interactions-from-pubsub"})
-;       (ds/map (fn [message]
-;                 (do
-;                   (log/info (str "Got transformed message:\n" message))
-;                   message)) {:name "log-transformed-message"})))


### PR DESCRIPTION
This pull request adds PubsubIO source and sinks to datasplash. As the datasplash `apply-transform` handles wrapping a PCollection elegantly and is well tested, there is no tests. Also due to the existing functionality, the commit is very small, as it took very little to get PubsubIO working. It is difficult to test this locally, as it Pubsub streaming jobs must be run on the Dataflow Service. I have added a (commented out) working example with the corresponding image from the Dataflow Dashboard.
<img width="591" alt="screen shot 2016-08-25 at 17 59 22" src="https://cloud.githubusercontent.com/assets/4218596/17977741/3b55257c-6af3-11e6-9545-67fd48af97a7.png">
