### PR TITLE
read-json-file: move a test out of the loop

### DIFF
--- a/src/datasplash/core.clj
+++ b/src/datasplash/core.clj
@@ -1175,13 +1175,13 @@ Example:
       (read-text-file from (-> options
                                (dissoc :coder)
                                (assoc :name "read-text-file")))
-      (dmap (fn [l]
-              (cond
-                (and key-fn return-type) (json/decode l key-fn return-type)
-                key-fn (json/decode l key-fn)
-                return-type (json/decode l nil return-type)
-                :else (json/decode l)))
-            (assoc options :name "json-decode")))))
+      (let [decode-fn (cond
+                        (and key-fn return-type) #(json/decode % key-fn return-type)
+                        key-fn #(json/decode % key-fn)
+                        return-type #(json/decode % nil return-type)
+                        :else #(json/decode %))]
+        (dmap decode-fn
+              (assoc options :name "json-decode"))))))
   ([from p] (read-json-file from {} p)))
 
 (def json-writer-schema


### PR DESCRIPTION
The current code performs a test at each loop iteration. This PR moves the test out of the loop (no pun intended). I don’t have any data on the performance improvement, thought.

I wasn’t able to run `lein test` because of an exception:

```
$ lein test
Retrieving org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.pom from central
Retrieving org/hamcrest/hamcrest-all/1.3/hamcrest-all-1.3.jar from central
Compiling datasplash.api-test
Compiling datasplash.examples
Compiling clj-time.core
Exception in thread "main" java.lang.NoClassDefFoundError: clojure/tools/logging/impl/LoggerFactory, compiling:(/tmp/form-init1405529213507449495.clj:1:73)
	at clojure.lang.Compiler.load(Compiler.java:7391)
```