### PR TITLE
Tests for windows bindings

### DIFF
--- a/src/datasplash/api.clj
+++ b/src/datasplash/api.clj
@@ -65,6 +65,7 @@
 
 (intern *ns* (with-meta 'frequencies (meta #'dt/dfrequencies)) @#'dt/dfrequencies)
 
+(intern *ns* (with-meta 'fixed-windows (meta #'dt/fixed-windows)) @#'dt/fixed-windows)
 (intern *ns* (with-meta 'sliding-windows (meta #'dt/sliding-windows)) @#'dt/sliding-windows)
 (intern *ns* (with-meta 'session-windows (meta #'dt/session-windows)) @#'dt/session-windows)
 

--- a/src/datasplash/core.clj
+++ b/src/datasplash/core.clj
@@ -1780,9 +1780,29 @@ Example:
     :accumulate-mode {:docstr "Accumulate mode when a Trigger is fired (accumulate or discard)"
                       :action (fn [transform acc] ((get accumulation-mode-enum acc) transform))}}))
 
+(defn fixed-windows
+  {:doc (with-opts-docstr
+          "Apply a fixed window to divide a PCollection (useful for unbounded PCollections).
+
+See https://cloud.google.com/dataflow/model/windowing#setting-fixed-time-windows
+
+Example:
+```
+(require '[clj-time.core :as time])
+(ds/fixed-windows (time/minutes 30) pcoll)
+```"
+          window-schema)
+   :added "0.4.1"}
+  ([width options ^PCollection pcoll]
+   (let [transform (-> (->duration width)
+                       (FixedWindows/of)
+                       (Window/into))]
+     (apply-transform pcoll transform window-schema options)))
+  ([width ^PCollection pcoll] (fixed-windows width {} pcoll)))
+
 (defn sliding-windows
   {:doc (with-opts-docstr
-          "Apply a sliding window input PCollection (useful for unbounded PCollections).
+          "Apply a sliding window to divide a PCollection (useful for unbounded PCollections).
 
 See https://cloud.google.com/dataflow/model/windowing#setting-sliding-time-windows
 
@@ -1803,7 +1823,7 @@ Example:
 
 (defn session-windows
   {:doc (with-opts-docstr
-          "Apply a Session window input PCollection (useful for unbounded PCollections).
+          "Apply a Session window to divide a PCollection (useful for unbounded PCollections).
 
 See https://cloud.google.com/dataflow/model/windowing#setting-session-windows
 
@@ -1819,4 +1839,4 @@ Example:
                        (Sessions/withGapDuration)
                        (Window/into))]
      (apply-transform pcoll transform window-schema options)))
-  ([gap ^PCollection pcoll] (sliding-windows gap {} pcoll)))
+  ([gap ^PCollection pcoll] (session-windows gap {} pcoll)))

--- a/src/datasplash/core.clj
+++ b/src/datasplash/core.clj
@@ -33,7 +33,7 @@
            [org.joda.time DateTimeUtils DateTimeZone]
            [org.joda.time.format DateTimeFormat DateTimeFormatter]
            [com.google.cloud.dataflow.sdk.transforms.windowing Window FixedWindows SlidingWindows Sessions Trigger]
-           [org.joda.time Duration]))
+           [org.joda.time Duration Instant]))
 
 (def required-ns (atom #{}))
 
@@ -263,7 +263,7 @@ See https://cloud.google.com/dataflow/java-sdk/JavaDoc/com/google/cloud/dataflow
   (ds/map (fn [e] (ds/with-timestamp (clj-time.core/now) (* 2 e)) pcoll))
   ```"
   [timestamp result]
-  (->TimeStamped timestamp result))
+  (->TimeStamped (Instant. (timc/to-long timestamp)) result))
 
 (defn output-value!
   [^DoFn$ProcessContext context entity bindings]

--- a/test/datasplash/api_test.clj
+++ b/test/datasplash/api_test.clj
@@ -319,4 +319,5 @@
         session (->> (ds/session-windows (time/seconds 2) p)
                      (ds/group-by-key)
                      (ds/map (fn [[_ elts]] (reduce + (map (fn [[k v]] v) elts))) {:name :sum}))]
-    (.. DataflowAssert (that session) (containsInAnyOrder #{0 3 4}))))
+    (.. DataflowAssert (that session) (containsInAnyOrder #{0 3 4}))
+    (ds/run-pipeline p)))

--- a/test/datasplash/api_test.clj
+++ b/test/datasplash/api_test.clj
@@ -6,7 +6,8 @@
             [clojure.test :refer :all]
             [datasplash
              [api :as ds]]
-            [me.raynes.fs :as fs])
+            [me.raynes.fs :as fs]
+            [clj-time.core :as time])
   (:import [com.google.cloud.dataflow.sdk.testing TestPipeline DataflowAssert]
            [java.io PushbackReader]))
 
@@ -293,3 +294,29 @@
         (is (= '(1 3.0 5 15) (sort res))))
       (let [res (read-file (first (glob-file sample-test)))]
         (is (= 2 (count res)))))))
+
+(deftest timestamp
+  (let [p (make-test-pipeline)
+        input (ds/generate-input [1 2 3 4 5] p)
+        proc (ds/map (fn [e] (ds/with-timestamp (time/now) e)) input)]
+    (ds/run-pipeline p)))
+
+(deftest windows
+  (let [now (time/now)
+        p (->> (make-test-pipeline)
+               (ds/generate-input [0. 0.5 2.5 3.])
+               (ds/map (fn [e] (ds/with-timestamp (time/minus now (time/seconds e)) e)) {:name :timestamp}))
+        sliding (ds/sliding-windows (time/seconds 2) (time/seconds 1) {:name :sliding} p)
+        fixed (ds/fixed-windows (time/seconds 2) {:name :fixed} p)]
+    (ds/run-pipeline p)))
+
+(deftest session-windows
+  (let [now (time/now)
+        p (->> (make-test-pipeline)
+               (ds/generate-input [[:k0 0] [:k1 1] [:k1 2] [:k0 4]])
+               (ds/map (fn [[k e]] (ds/with-timestamp (time/minus now (time/seconds e)) [k e])) {:name :timestamp})
+               (ds/with-keys (fn [e] (get e 0))))
+        session (->> (ds/session-windows (time/seconds 2) p)
+                     (ds/group-by-key)
+                     (ds/map (fn [[_ elts]] (reduce + (map (fn [[k v]] v) elts))) {:name :sum}))]
+    (.. DataflowAssert (that session) (containsInAnyOrder #{0 3 4}))))


### PR DESCRIPTION
Also:
- fixed (and tested) ds/with-timestamp function (now we know it works thanks to the sessions-window test)
- added fixed windows

Missing:
- complete test for fixed and sliding windows, for now it's just a test to see if the pipeline run, but not on the results.