### PR TITLE
Replace ? with _ instead of removing for bq field names

### DIFF
--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -76,7 +76,7 @@
         (cond-> test (str))
         (name)
         (str/replace #"-" "_")
-        (str/replace #"\?" ""))))
+        (str/replace #"\?" "_"))))
 
 
 (defn bqize-keys


### PR DESCRIPTION
This is to align with the way that BQ renames fields when creating auto schema. For example, from a DataStore backup.