### PR TITLE
Updates to the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here is the classic word count:
                :default 0}})
 
 (defn -main
-  [str-args]
+  [& str-args]
   (let [p (ds/make-pipeline WordCountOptions str-args)
         {:keys [input output numShards]} (ds/get-pipeline-options p)]
     (->> p

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Here is the classic word count:
          (ds/mapcat tokenize {:name :tokenize})
          (ds/frequencies)
          (ds/map (fn [[k v]] (format "%s: %d" k v)) {:name :format-count})
-         (ds/write-text-file output {:num-shards numShards}))))
+         (ds/write-text-file output {:num-shards numShards})
+         (ds/run-pipeline)))
 ```
 
 Run it locally with:


### PR DESCRIPTION
Without the ampersand the README example would throw "clojure.lang.ArityException: Wrong number of args (2) passed to: core/-main".