### PR TITLE
Added support for time partitioned big query tables

### DIFF
--- a/test/datasplash/bq_test.clj
+++ b/test/datasplash/bq_test.clj
@@ -1,0 +1,12 @@
+(ns datasplash.bq-test
+  (:require [clojure.test :refer :all]
+            [datasplash.bq :refer :all]))
+
+(deftest ->time-partitioning-test
+  (are [opts expected]
+    (let [tp (-> opts ->time-partitioning bean (select-keys [:type :expirationMs]))]
+      (= expected tp))
+    {} {:type "DAY" :expirationMs nil}
+    {:type :day} {:type "DAY" :expirationMs nil}
+    {:type :day :expiration-ms 1000} {:type "DAY" :expirationMs 1000}
+    {:expiration-ms "bad format"} {:type "DAY" :expirationMs nil}))


### PR DESCRIPTION
Simple extension to reference day partitions with BigQuery outputs