### PR TITLE
Extended BQ time partitioning options with setField

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject datasplash "0.6.1"
+(defproject datasplash "0.6.2-SNAPSHOT"
   :description "Clojure API for a more dynamic Google Cloud Dataflow and (hopefully) Apache BEAM"
   :url "https://github.com/ngrunwald/datasplash"
   :license {:name "Eclipse Public License"

--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -145,12 +145,13 @@
   ([defs] (->schema defs name)))
 
 (defn ^TimePartitioning ->time-partitioning
-  [{:keys [type expiration-ms field]
+  [{:keys [type expiration-ms field require-partition-filter]
     :or   {type :day}}]
   (let [tp (doto (TimePartitioning.) (.setType (-> type name .toUpperCase)))]
     (cond-> tp
-            (int? expiration-ms) (.setExpirationMs expiration-ms)
-            (string? field)      (.setField field))))
+            (int? expiration-ms)                   (.setExpirationMs expiration-ms)
+            (string? field)                        (.setField field)
+            (boolean? require-partition-filter)    (.setRequirePartitionFilter require-partition-filter))))
 
 (defn get-bq-table-schema
   "Beware, uses bq util to get the schema!"

--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -145,11 +145,12 @@
   ([defs] (->schema defs name)))
 
 (defn ^TimePartitioning ->time-partitioning
-  [{:keys [type expiration-ms]
+  [{:keys [type expiration-ms field]
     :or   {type :day}}]
   (let [tp (doto (TimePartitioning.) (.setType (-> type name .toUpperCase)))]
-    (when (int? expiration-ms) (.setExpirationMs tp expiration-ms))
-    tp))
+    (cond-> tp
+            (int? expiration-ms) (.setExpirationMs expiration-ms)
+            (string? field)      (.setField field))))
 
 (defn get-bq-table-schema
   "Beware, uses bq util to get the schema!"


### PR DESCRIPTION
Added the possibility to define a (BQ) field upon which time partioning is based instead of default value (_PARTITIONTIME). The field must be a DATE or a TIMESTAMP