### PR TITLE
Remove deprecated functions

### DIFF
--- a/src/clj/datasplash/api.clj
+++ b/src/clj/datasplash/api.clj
@@ -56,8 +56,6 @@
 
 (intern *ns* (with-meta 'partition-fn (meta #'dt/partition-fn)) @#'dt/partition-fn)
 (intern *ns* (with-meta 'partition-by (meta #'dt/dpartition-by)) @#'dt/dpartition-by)
-(intern *ns* (with-meta 'write-edn-file-by (meta #'dt/write-edn-file-by)) @#'dt/write-edn-file-by)
-(intern *ns* (with-meta 'write-text-file-by (meta #'dt/write-text-file-by)) @#'dt/write-text-file-by)
 (intern *ns* (with-meta 'make-partition-mapping (meta #'dt/make-partition-mapping)) @#'dt/make-partition-mapping)
 
 (intern *ns* (with-meta 'side-inputs (meta #'dt/side-inputs)) @#'dt/side-inputs)

--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -1315,21 +1315,6 @@ Example:
          (output-transform path (assoc safe-opts :name (str "write-partial-file-" idx)) coll))
        pcoll))))
 
-(defn write-file-by
-  {:doc (with-opts-docstr
-          ""
-          base-schema text-writer-schema)
-   :added "0.1.0"
-   :deprecated "0.2.0"}
-  ([encoder f mapping to options ^PCollection pcoll]
-   (let [opts (assoc options :label "write-edn-file-by" :coder nil)
-         ptrans (write-text-file-by-transform encoder f mapping to opts)]
-     (apply-transform pcoll ptrans named-schema opts)))
-  ([encoder f mapping to pcoll] (write-file-by encoder f  mapping to {} pcoll)))
-
-(def ^{:deprecated "0.2.0"} write-edn-file-by (partial write-file-by write-edn-file))
-(def ^{:deprecated "0.2.0"} write-text-file-by (partial write-file-by write-text-file))
-
 ;;;;;;;;;;;
 ;; Joins ;;
 ;;;;;;;;;;;


### PR DESCRIPTION
Those have been deprecated since `0.2.0`. It is, however, a breaking change.