### PR TITLE
Make generate-input support empty collections

### DIFF
--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -619,11 +619,11 @@ Example:
           base-schema)
    :added "0.1.0"}
   ([coll options ^Pipeline p]
-   (let [opts (merge {:coder (make-nippy-coder)}
-                     (assoc options :label :generate-input))
+   (let [{:keys [coder] :as opts} (merge {:coder (make-nippy-coder)}
+                                (assoc options :label :generate-input))
          ptrans (if (empty? coll)
-                  (Create/empty (make-nippy-coder))
-                  (Create/of coll))]
+                 (Create/empty coder)
+                 (Create/of coll))]
      (apply-transform p ptrans base-schema opts)))
   ([coll p] (generate-input coll {} p)))
 

--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -609,6 +609,7 @@ returns true.
 (defn generate-input
   {:doc (with-opts-docstr
           "Generates a pcollection from the given collection.
+Also accepts empty collections.
 See https://cloud.google.com/dataflow/java-sdk/JavaDoc/com/google/cloud/dataflow/sdk/transforms/Create.html
 
 Example:
@@ -620,7 +621,9 @@ Example:
   ([coll options ^Pipeline p]
    (let [opts (merge {:coder (make-nippy-coder)}
                      (assoc options :label :generate-input))
-         ptrans (Create/of coll)]
+         ptrans (if (empty? coll)
+                  (Create/empty (make-nippy-coder))
+                  (Create/of coll))]
      (apply-transform p ptrans base-schema opts)))
   ([coll p] (generate-input coll {} p)))
 
@@ -857,7 +860,7 @@ Example (actual implementation of the group-by transform):
 ```"
    :added "0.1.0"}
   [nam input & body]
-  `(let [body-fn# (fn [~(last input)] ~@body)] 
+  `(let [body-fn# (fn [~(last input)] ~@body)]
      (ClojurePTransform. body-fn#)))
 
 (defmacro pt->>
@@ -1130,11 +1133,11 @@ It means the template %A-%U-%T is equivalent to the default jobName"
                                (fn [transform enum] (.withCompression transform enum)))}
    :num-shards {:docstr "Selects the desired number of output shards (file fragments). 0 to let the system decide (recommended)."
                 :action (fn [transform shards] (.withNumShards transform shards))}
-   
+
    :temp-directory {:docstr "Use temp directory when using Filename Policy as output (see filename-policy fn)"
                     :action (fn [transform prefix] (when prefix
                                                      (.withTempDirectory transform prefix)))}
-   
+
    :suffix {:docstr "Uses the given filename suffix."
             :action (fn [transform suffix] (.withSuffix transform suffix))}
    :prefix {:docstr "Uses the given filename prefix."

--- a/src/clj/datasplash/datastore.clj
+++ b/src/clj/datasplash/datastore.clj
@@ -30,6 +30,15 @@
                    (cond-> num-query-split (.withNumQuerySplits num-query-split)))]
     (apply-transform pcoll ptrans named-schema opts)))
 
+(defn delete-datastore-raw
+  "delete a pcoll of already generated datastore entity from datastore"
+  [{:keys [project-id] :as options} pcoll]
+  (let [opts (assoc options :label :delete-datastore-raw)
+        ptrans (-> (DatastoreIO/v1)
+                   (.deleteEntity)
+                   (.withProjectId project-id))]
+    (apply-transform pcoll ptrans named-schema opts)))
+
 (declare value->clj)
 (declare entity->clj)
 

--- a/src/clj/datasplash/datastore.clj
+++ b/src/clj/datasplash/datastore.clj
@@ -30,15 +30,6 @@
                    (cond-> num-query-split (.withNumQuerySplits num-query-split)))]
     (apply-transform pcoll ptrans named-schema opts)))
 
-(defn delete-datastore-raw
-  "delete a pcoll of already generated datastore entity from datastore"
-  [{:keys [project-id] :as options} pcoll]
-  (let [opts (assoc options :label :delete-datastore-raw)
-        ptrans (-> (DatastoreIO/v1)
-                   (.deleteEntity)
-                   (.withProjectId project-id))]
-    (apply-transform pcoll ptrans named-schema opts)))
-
 (declare value->clj)
 (declare entity->clj)
 


### PR DESCRIPTION
This pull request adds a switch on collection emptiness in generate-input to make the function support empty Pcollections generation.

Indeed, the method Create/of does not accept empty collections since it cannot guess which coder to use, so that `(ds/generate-input [] {:name "my-transform"} pipeline)` throws an Exception.
Instead, we must use Create/empty with a coder as argument (here a nippy coder), which is done there.

This feature can be useful for pipeline automation when you do not want to read data everytime (at certain hours for instance) and thus to do not break the pipeline with nil you would have to check everywhere. 