### PR TITLE
Add read-x-files transforms

### DIFF
--- a/src/clj/datasplash/api.clj
+++ b/src/clj/datasplash/api.clj
@@ -101,8 +101,11 @@
 ;;;;;;;;;;;;;
 
 (intern *ns* (with-meta 'read-text-file (meta #'dt/read-text-file)) @#'dt/read-text-file)
+(intern *ns* (with-meta 'read-text-files (meta #'dt/read-text-files)) @#'dt/read-text-files)
 (intern *ns* (with-meta 'read-edn-file (meta #'dt/read-edn-file)) @#'dt/read-edn-file)
+(intern *ns* (with-meta 'read-edn-files (meta #'dt/read-edn-files)) @#'dt/read-edn-files)
 (intern *ns* (with-meta 'read-json-file (meta #'dt/read-json-file)) @#'dt/read-json-file)
+(intern *ns* (with-meta 'read-json-files (meta #'dt/read-json-files)) @#'dt/read-json-files)
 (intern *ns* (with-meta 'write-text-file (meta #'dt/write-text-file)) @#'dt/write-text-file)
 (intern *ns* (with-meta 'write-edn-file (meta #'dt/write-edn-file)) @#'dt/write-edn-file)
 (intern *ns* (with-meta 'write-json-file (meta #'dt/write-json-file)) @#'dt/write-json-file)


### PR DESCRIPTION
**Additions description**

Add the following transforms to datasplash :

- read-text-files
- read-edn-files
- read-json-files

mirroring singular versions.

These transforms take a PCollection of uris/paths (String) as input and spawn a single PTransform in the graph. 

**Covered use case**

In some cases, the user has to read from a large number of files but without the possibility to create a single pattern for it, which is the case when a datasource is separated into many daily folders.
In that case, we have two possibilities:

- match all folders, then filter read data, which can be overkill and very costly when you need only a smaller subset of the data
- spawn a read transform for every file, which can cause an exception because the graph is too large (like if you want to read from 250 files)

Here, the proposed functions allow the user to prefilter the files he/she need before execution (by using google-cloud-java for instance).

**Example**

```
(->> (ds/generate-input [\"gs://target/path\" \"gs://target/another-path\"] pipeline)
         (ds/read-json-files {:key-fn keyword}))
```