### PR TITLE
fix readme example to include :file-format in options map

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Here is the classic word count:
          (ds/mapcat tokenize {:name :tokenize})
          (ds/frequencies)
          (ds/map (fn [[k v]] (format "%s: %d" k v)) {:name :format-count})
-         (ds/write-text-file output {:num-shards numShards})
+         (ds/write-text-file output {:num-shards numShards
+                                     :file-format str})
          (ds/run-pipeline)))
 ```
 Run it from the repl with:


### PR DESCRIPTION
I'm new to datasplash and Beam and encountered #77.  After looking at the source, it seems that `:file-format` is necessary.  I was able to run the pipeline successfully from the REPL with the included change.    

Not sure what the function should be for `:file-format` but either `str` or `identity` seem to work.