### PR TITLE
0.8.0-wip : java typing fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,30 +3,33 @@
   :url "https://github.com/ngrunwald/datasplash"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [cheshire "5.10.0"]
+  :dependencies [[cheshire "5.10.0"]
                  [clj-stacktrace "0.2.8"]
-                 [org.apache.beam/beam-sdks-java-core "2.26.0"]
-                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.26.0"]
-                 [org.apache.beam/beam-sdks-java-io-kafka "2.26.0"]
-                 [org.apache.beam/beam-runners-direct-java "2.26.0"]
-                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.26.0"]
-                 [org.apache.beam/beam-runners-core-java "2.26.0"]
-                 [org.apache.kafka/kafka-clients "2.5.0"]
-                 [com.taoensso/nippy "2.14.0"]
+                 [clj-time "0.15.2"]
+                 [com.taoensso/nippy "2.14.0"] ; TODO: resolve to upgrade
+                 [org.apache.beam/beam-sdks-java-core "2.28.0"]
+                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.28.0"]
+                 [org.apache.beam/beam-sdks-java-io-kafka "2.28.0"]
+                 [org.apache.beam/beam-runners-direct-java "2.28.0"]
+                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.28.0"]
+                 [org.apache.beam/beam-runners-core-java "2.28.0"]
+                 [org.apache.kafka/kafka-clients "2.7.0"]
+                 [org.clojure/clojure "1.10.3"]
                  [org.clojure/math.combinatorics "0.1.6"]
                  [org.clojure/tools.logging "1.1.0"]
-                 [clj-time "0.15.2"]
                  [superstring "3.0.0"]]
   :source-paths ["src/clj"]
   :pedantic? false
   :java-source-paths ["src/java"]
+  :javac-options ["-Xlint:unchecked"]
   :deploy-repositories {"releases" {:url "https://repo.clojars.org"}}
-  :profiles {:dev {:dependencies [[junit/junit "4.13"]
+  :profiles {:dev {:dependencies [[junit/junit "4.13.2"]
                                   [me.raynes/fs "1.4.6"]
                                   [org.hamcrest/hamcrest-all "1.3"]
-                                  [org.slf4j/slf4j-api "1.7.30"]
-                                  [org.slf4j/slf4j-jdk14 "1.7.30"]]
+                                  ;; [org.slf4j/slf4j-api "1.7.30"]
+                                  ;; [org.slf4j/slf4j-jdk14 "1.7.30"]
+                                  [org.apache.logging.log4j/log4j-slf4j-impl "2.14.1"]
+                                  [org.apache.logging.log4j/log4j-core "2.14.1"]]
                    :aot  [clojure.tools.logging.impl datasplash.api-test datasplash.examples clj-time.core datasplash.core clojure.tools.reader.reader-types]}
              :uberjar {:aot :all}}
   :main datasplash.examples)

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[cheshire "5.10.0"]
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
-                 [com.taoensso/nippy "2.14.0"] ; TODO: resolve to upgrade
+                 [com.taoensso/nippy "3.1.1"]
                  [org.apache.beam/beam-sdks-java-core "2.28.0"]
                  [org.apache.beam/beam-sdks-java-io-elasticsearch "2.28.0"]
                  [org.apache.beam/beam-sdks-java-io-kafka "2.28.0"]

--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -395,6 +395,10 @@ See https://cloud.google.com/dataflow/java-sdk/JavaDoc/com/google/cloud/dataflow
   [^DoFn$ProcessContext c]
   (.output c (.element c)))
 
+(alter-var-root #'nippy/*thaw-serializable-allowlist*
+                (fn [_] (into nippy/default-thaw-serializable-allowlist
+                             #{"org.apache.beam.sdk.values.KV"})))
+
 (defn make-nippy-coder
   {:doc "Returns an instance of a CustomCoder using nippy for serialization"
    :added "0.1.0"}

--- a/src/clj/datasplash/datastore.clj
+++ b/src/clj/datasplash/datastore.clj
@@ -137,7 +137,7 @@
   builder)
 
 (defn- make-ds-entity-builder
-  [raw-values {:keys [exclude-from-index] :as options}]
+  [raw-values {:keys [exclude-from-index]}]
   (let [excluded-set (into #{} (map name exclude-from-index))
         ^Entity$Builder entity-builder (Entity/newBuilder)]
     (doseq [[v-key v-val] raw-values]
@@ -155,7 +155,7 @@
 
 (defn make-ds-entity
   "Builds a Datastore Entity with the given Clojure value which is a map or seq of KVs corresponding to the desired entity, and options contains an optional key, ancestor, namespace, kind and an optional set of field names that shoud not be indexed (only supported for top level fields for now). Supports repeated fields and nested entities (as nested map)"
-  ([raw-values {:keys [key namespace kind ancestors exclude-from-index] :as options}]
+  ([raw-values {:keys [key] :as options}]
    (let [^Entity$Builder builder (-> (make-ds-entity-builder raw-values options)
                                      (cond-> key (add-ds-key-namespace-kind options)))]
      (.build builder)))

--- a/src/clj/datasplash/es.clj
+++ b/src/clj/datasplash/es.clj
@@ -37,7 +37,7 @@
   [max-attempts max-duration-ms]
   (let [duration (Duration. max-duration-ms)]
     (ElasticsearchIO$RetryConfiguration/create max-attempts duration)))
-  
+
 (def ^:no-doc read-es-schema
   (merge
    es-connection-schema

--- a/src/clj/datasplash/examples.clj
+++ b/src/clj/datasplash/examples.clj
@@ -36,7 +36,7 @@
 
 (defoptions WordCountOptions
   {:input {:default "gs://apache-beam-samples/shakespeare/kinglear.txt"
-           :type String} 
+           :type String}
    :output {:default "kinglear-freqs.txt"
             :type String}
    :numShards {:default 0
@@ -61,7 +61,7 @@
 
 (defoptions DeDupOptions
   {:input {:default "gs://apache-beam-samples/shakespeare/*"
-           :type String} 
+           :type String}
    :output {:default "shakespeare-dedup.txt"
             :type String}})
 
@@ -90,7 +90,7 @@
 
 (defn run-filter
   [str-args]
-  (let [p (ds/make-pipeline FilterOptions str-args) 
+  (let [p (ds/make-pipeline FilterOptions str-args)
         {:keys [input output monthFilter]} (ds/get-pipeline-options p)
         all-rows (->> p
                       (bq/read-bq {:table input})
@@ -196,7 +196,7 @@
 
 (def StandardSQLOptions
   {:input {:default "bigquery-public-data.samples.shakespeare"
-           :type String} 
+           :type String}
    :output {:default "project:dataset.table"
             :type String}
    :tempLocation {:default "gs://yourbucket"
@@ -206,7 +206,7 @@
   [str-args]
   ;; the DirectPipelineRunner doesn't support standardSql yet
   (let [p (ds/make-pipeline StandardSQLOptions str-args {:runner "DataflowRunner"})
-        {:keys [input output]} (ds/get-pipeline-options p)
+        {:keys [_input output]} (ds/get-pipeline-options p)
         query "SELECT * from `bigquery-public-data.samples.shakespeare` LIMIT 100"
         results (->> p
                      (bq/read-bq {:query query
@@ -221,9 +221,9 @@
 
 (defoptions DatastoreWordCountOptions
   {:input {:default "gs://apache-beam-samples/shakespeare/kinglear.txt"
-           :type String} 
+           :type String}
    :output {:default "kinglear-freqs.txt"
-            :type String} 
+            :type String}
    :dataset {:default "yourdataset"
              :type String}
    :kind {:default "yourkind"
@@ -242,7 +242,7 @@
 ;; Query is not wrapped yet, use Interop
 ;; PR welcome :)
 (defn make-ancestor-kind-query
-  [{:keys [kind namespace] :as opts}]
+  [{:keys [kind _namespace] :as opts}]
   (let [qb (Query/newBuilder)]
     (-> qb (.addKindBuilder) (.setName kind))
     (.setFilter qb (DatastoreHelper/makeFilter
@@ -299,9 +299,9 @@
  (->> pipeline
       (ps/read-from-pubsub read-topic {:name "read-interactions-from-pubsub" :kind :topic})
       (ds/map (fn [message]
-                (do
-                  (log/info (str "Got message:\n" message))
-                  (str/reverse message))) {:name "log-message"})
+                (log/info (str "Got message:\n" message))
+                (str/reverse message))
+              {:name "log-message"})
       (ps/write-to-pubsub write-transformed-topic {:name "write-forwarded-interactions-to-pubsub"})))
 
 (defn stream-forwarded-interactions-from-pubsub
@@ -309,9 +309,9 @@
  (->> pipeline
       (ps/read-from-pubsub read-transformed-subscription {:name "read-transformed-interactions-from-pubsub"})
       (ds/map (fn [message]
-                (do
-                  (log/info (str "Got transformed message:\n" message))
-                  message)) {:name "log-transformed-message"})))
+                (log/info (str "Got transformed message:\n" message))
+                message)
+              {:name "log-transformed-message"})))
 
 
 (defn run-pub-sub

--- a/src/clj/datasplash/kafka.clj
+++ b/src/clj/datasplash/kafka.clj
@@ -109,10 +109,10 @@
 ```
     {:payload   \"Deserialized with `value-deserializer`\"
      :key       \"Deserialized with `key-deserializer`\"
-     :offset    \"...\"     
+     :offset    \"...\"
      :partition \"...\"
-     :timestamp \"...\"   
-     :topic     \"...\"   
+     :timestamp \"...\"
+     :topic     \"...\"
      :headers   \"A map of `{key values}` of `Header` (https://www.javadoc.io/static/org.apache.kafka/kafka-clients/1.0.0/org/apache/kafka/common/header/Header.html)\"}
 ```
 

--- a/src/java/AbstractClojureDoFn.java
+++ b/src/java/AbstractClojureDoFn.java
@@ -17,7 +17,7 @@ public abstract class AbstractClojureDoFn extends DoFn<Object, Object> {
     protected final IFn finishBundleFn;
     protected final IFn initializeFn;
 
-    public AbstractClojureDoFn(Map<String, IFn>  fns_map) {
+    public AbstractClojureDoFn(Map<String, IFn> fns_map) {
         super();
         doFn = fns_map.get("dofn");
         windowFn = fns_map.get("window-fn");

--- a/src/java/ClojureCombineFn.java
+++ b/src/java/ClojureCombineFn.java
@@ -18,51 +18,49 @@ public final class ClojureCombineFn extends CombineFn<Object, Object, Object> {
     private final IFn combineFnRaw;
     private final Coder accCoder;
     private final Coder outputCoder;
-    
-    public ClojureCombineFn(Map<String, IFn>  fns_map, Coder output_coder , Coder acc_coder ) {
+
+    public ClojureCombineFn(Map<String, IFn> fns_map, Coder output_coder, Coder acc_coder) {
         super();
         initFn = fns_map.get("init-fn");
         extractFn = fns_map.get("extract-fn");
         reduceFn = fns_map.get("reduce-fn");
         combineFn = fns_map.get("combine-fn");
-	combineFnRaw = fns_map.get("combine-fn-raw");
-	accCoder = acc_coder;
-	outputCoder = output_coder;
+        combineFnRaw = fns_map.get("combine-fn-raw");
+        accCoder = acc_coder;
+        outputCoder = output_coder;
     }
-    public Object createAccumulator () {
-	return initFn.invoke() ;
+    public Object createAccumulator() {
+        return initFn.invoke();
     }
-    public Object addInput (Object acc , Object elt) {
-	return reduceFn.invoke(acc, elt);
+    public Object addInput(Object acc, Object elt) {
+        return reduceFn.invoke(acc, elt);
     }
-    public Object mergeAccumulators (Iterable<Object> accs) {
-	return combineFn.invoke(accs);
+    public Object mergeAccumulators(Iterable<Object> accs) {
+        return combineFn.invoke(accs);
     }
-    public Object extractOutput (Object acc) {
-	return extractFn.invoke(acc);
+    public Object extractOutput(Object acc) {
+        return extractFn.invoke(acc);
     }
-    
 
     public Coder getDefaultOutputCoder(Object a, Object b) {
-	return outputCoder;
+        return outputCoder;
     }
-    public Coder getAccumulatorCoder(Object a , Object b) {
-	return accCoder;
+    public Coder getAccumulatorCoder(Object a, Object b) {
+        return accCoder;
     }
 
-    public IFn getInitFn () {
-	return initFn ;
+    public IFn getInitFn() {
+        return initFn;
     }
-    public IFn getReduceFn () {
-	return reduceFn ;
+    public IFn getReduceFn() {
+        return reduceFn;
     }
-    
-    public IFn getMergeFn () {
-	return combineFnRaw ;
+
+    public IFn getMergeFn() {
+        return combineFnRaw;
     }
-    
-    public IFn getExtractFn () {
-	return extractFn ;
+
+    public IFn getExtractFn() {
+        return extractFn;
     }
-    
 }

--- a/src/java/ClojureCombineFn.java
+++ b/src/java/ClojureCombineFn.java
@@ -16,10 +16,10 @@ public final class ClojureCombineFn extends CombineFn<Object, Object, Object> {
     private final IFn reduceFn;
     private final IFn combineFn;
     private final IFn combineFnRaw;
-    private final Coder accCoder;
-    private final Coder outputCoder;
+    private final Coder<Object> accCoder;
+    private final Coder<Object> outputCoder;
 
-    public ClojureCombineFn(Map<String, IFn> fns_map, Coder output_coder, Coder acc_coder) {
+    public ClojureCombineFn(Map<String, IFn> fns_map, Coder<Object> output_coder, Coder<Object> acc_coder) {
         super();
         initFn = fns_map.get("init-fn");
         extractFn = fns_map.get("extract-fn");
@@ -42,10 +42,10 @@ public final class ClojureCombineFn extends CombineFn<Object, Object, Object> {
         return extractFn.invoke(acc);
     }
 
-    public Coder getDefaultOutputCoder(Object a, Object b) {
+    public Coder<Object> getDefaultOutputCoder(Object a, Object b) {
         return outputCoder;
     }
-    public Coder getAccumulatorCoder(Object a, Object b) {
+    public Coder<Object> getAccumulatorCoder(Object a, Object b) {
         return accCoder;
     }
 

--- a/src/java/ClojureCustomCoder.java
+++ b/src/java/ClojureCustomCoder.java
@@ -13,25 +13,23 @@ public final class ClojureCustomCoder extends CustomCoder {
     private static final long serialVersionUID = 0;
     private final IFn encodeFn;
     private final IFn decodeFn;
-       
+
     public ClojureCustomCoder(Map<String, IFn>  fns_map ) {
         super();
         encodeFn = fns_map.get("encode-fn");
         decodeFn = fns_map.get("decode-fn");
-        
     }
-    public void encode (Object obj, OutputStream out) {
-	encodeFn.invoke(obj,out) ;
+    public void encode(Object obj, OutputStream out) {
+        encodeFn.invoke(obj,out);
     }
-    
-    public Object decode ( InputStream in) {
-	return decodeFn.invoke(in) ;
-    }
-    
 
-    public void verifyDeterministic () {
+    public Object decode(InputStream in) {
+        return decodeFn.invoke(in);
     }
-    public boolean consistentWithEquals () {
-	return true ;
+
+    public void verifyDeterministic() {
+    }
+    public boolean consistentWithEquals() {
+        return true;
     }
 }

--- a/src/java/ClojureCustomCoder.java
+++ b/src/java/ClojureCustomCoder.java
@@ -8,7 +8,7 @@ import java.io.OutputStream;
 import clojure.lang.IFn;
 import clojure.java.api.Clojure;
 
-public final class ClojureCustomCoder extends CustomCoder {
+public final class ClojureCustomCoder extends CustomCoder<Object> {
 
     private static final long serialVersionUID = 0;
     private final IFn encodeFn;

--- a/src/java/ClojureDoFn.java
+++ b/src/java/ClojureDoFn.java
@@ -24,7 +24,7 @@ public class ClojureDoFn extends AbstractClojureDoFn {
     }
 
     @ProcessElement
-    public void processElement(ProcessContext c , BoundedWindow w) {
+    public void processElement(ProcessContext c, BoundedWindow w) {
         HashMap extra = new HashMap();
         extra.put("window", w);
         extra.put("system", system);

--- a/src/java/ClojureDoFn.java
+++ b/src/java/ClojureDoFn.java
@@ -10,6 +10,8 @@ import clojure.java.api.Clojure;
 
 public class ClojureDoFn extends AbstractClojureDoFn {
 
+    private static final long serialVersionUID = 1L;
+
     private transient Object system = null;
 
     public ClojureDoFn(Map<String, IFn> fns_map) {

--- a/src/java/ClojureDoFn.java
+++ b/src/java/ClojureDoFn.java
@@ -25,7 +25,7 @@ public class ClojureDoFn extends AbstractClojureDoFn {
 
     @ProcessElement
     public void processElement(ProcessContext c, BoundedWindow w) {
-        HashMap extra = new HashMap();
+        HashMap<String, Object> extra = new HashMap<String, Object>();
         extra.put("window", w);
         extra.put("system", system);
         doFn.invoke(c, extra);

--- a/src/java/ClojurePTransform.java
+++ b/src/java/ClojurePTransform.java
@@ -12,17 +12,13 @@ public final class ClojurePTransform extends PTransform<PInput,POutput> {
 
     private static final long serialVersionUID = 0;
     private final IFn bodyFn;
-           
+
     public ClojurePTransform(IFn body_fn) {
         super();
         bodyFn = body_fn;
-        
-        
     }
-    public POutput expand (PInput input) {
-	POutput res = (POutput)  bodyFn.invoke(input);
-	return res ;
+    public POutput expand(PInput input) {
+        POutput res = (POutput) bodyFn.invoke(input);
+        return res;
     }
-    
-    
 }

--- a/src/java/ClojureStatefulDoFn.java
+++ b/src/java/ClojureStatefulDoFn.java
@@ -30,7 +30,7 @@ public final class ClojureStatefulDoFn extends AbstractClojureDoFn {
 
     @ProcessElement
     public void processElement(ProcessContext c, BoundedWindow w, @StateId("state") ValueState state) {
-        HashMap extra = new HashMap();
+        HashMap<String, Object> extra = new HashMap<String, Object>();
         extra.put("state", state);
         extra.put("window", w);
         extra.put("system", system);

--- a/src/java/ClojureStatefulDoFn.java
+++ b/src/java/ClojureStatefulDoFn.java
@@ -29,7 +29,7 @@ public final class ClojureStatefulDoFn extends AbstractClojureDoFn {
      }
 
     @ProcessElement
-    public void processElement(ProcessContext c, BoundedWindow w, @StateId("state") ValueState state) {
+    public void processElement(ProcessContext c, BoundedWindow w, @StateId("state") ValueState<Object> state) {
         HashMap<String, Object> extra = new HashMap<String, Object>();
         extra.put("state", state);
         extra.put("window", w);

--- a/src/java/ClojureStatefulDoFn.java
+++ b/src/java/ClojureStatefulDoFn.java
@@ -21,11 +21,11 @@ public final class ClojureStatefulDoFn extends AbstractClojureDoFn {
         super(fns_map);
     }
 
-     @Setup
+    @Setup
     public void initialize() {
-         if (initializeFn != null) {
-             system = initializeFn.invoke();
-         }
+        if (initializeFn != null) {
+            system = initializeFn.invoke();
+        }
      }
 
     @ProcessElement
@@ -33,7 +33,7 @@ public final class ClojureStatefulDoFn extends AbstractClojureDoFn {
         HashMap extra = new HashMap();
         extra.put("state", state);
         extra.put("window", w);
-        extra.put("system",system);
+        extra.put("system", system);
         doFn.invoke(c, extra);
         windowFn.invoke(w);
     }

--- a/src/java/ClojureStatefulDoFn.java
+++ b/src/java/ClojureStatefulDoFn.java
@@ -13,6 +13,8 @@ import clojure.lang.IFn;
 
 public final class ClojureStatefulDoFn extends AbstractClojureDoFn {
 
+    private static final long serialVersionUID = 1L;
+
     @StateId("state")
     private final StateSpec<ValueState<Object>> stateSpec = StateSpecs.value(new NippyCoder());
     private transient Object system = null;

--- a/src/java/ExtractKeyFn.java
+++ b/src/java/ExtractKeyFn.java
@@ -10,25 +10,25 @@ import clojure.java.api.Clojure;
 
 public class ExtractKeyFn implements ElasticsearchIO.Write.FieldValueExtractFn {
 
-  private final IFn keyFn;
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final IFn keyFn;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  public ExtractKeyFn(IFn keyFunction) {
-    super();
-    keyFn = keyFunction;
-  }
-
-  @Override
-  public String apply(JsonNode input) {
-    String jsonString;
-    try {
-      if (input.isMissingNode()) {
-	throw new RuntimeException("Unable to extract field: " + input.asText());
-      }
-      jsonString = MAPPER.writer().writeValueAsString(input);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
+    public ExtractKeyFn(IFn keyFunction) {
+        super();
+        keyFn = keyFunction;
     }
-    return String.valueOf(keyFn.invoke(jsonString));
-  }
+
+    @Override
+    public String apply(JsonNode input) {
+        String jsonString;
+        try {
+            if (input.isMissingNode()) {
+                throw new RuntimeException("Unable to extract field: " + input.asText());
+            }
+            jsonString = MAPPER.writer().writeValueAsString(input);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return String.valueOf(keyFn.invoke(jsonString));
+    }
 }

--- a/src/java/ExtractKeyFn.java
+++ b/src/java/ExtractKeyFn.java
@@ -10,6 +10,8 @@ import clojure.java.api.Clojure;
 
 public class ExtractKeyFn implements ElasticsearchIO.Write.FieldValueExtractFn {
 
+    private static final long serialVersionUID = 1L;
+
     private final IFn keyFn;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/src/java/FileNamePolicy.java
+++ b/src/java/FileNamePolicy.java
@@ -25,15 +25,15 @@ public final class FileNamePolicy extends FileBasedSink.FilenamePolicy {
     private final ResourceId prefix;
     private final String raw_prefix;
 
-        public FileNamePolicy (Map<String, Object> params_map) {
-      super();
-      windowedFn = (IFn) params_map.get("windowed-fn");
-      unwindowedFn = (IFn) params_map.get("unwindowed-fn");
-      raw_prefix = (String) params_map.get("prefix");
-      prefix = FileBasedSink.convertToFileResourceIfPossible(raw_prefix);
+    public FileNamePolicy(Map<String, Object> params_map) {
+        super();
+        windowedFn = (IFn) params_map.get("windowed-fn");
+        unwindowedFn = (IFn) params_map.get("unwindowed-fn");
+        raw_prefix = (String) params_map.get("prefix");
+        prefix = FileBasedSink.convertToFileResourceIfPossible(raw_prefix);
     }
 
-    public ResourceId windowedFilename(int shardNumber, int numShards,BoundedWindow window, PaneInfo paneInfo, OutputFileHints outputFileHints) {
+    public ResourceId windowedFilename(int shardNumber, int numShards, BoundedWindow window, PaneInfo paneInfo, OutputFileHints outputFileHints) {
         String fileName = (String) windowedFn.invoke(shardNumber, numShards, window, outputFileHints.getSuggestedFilenameSuffix());
         return prefix.getCurrentDirectory().resolve(fileName, ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
     }
@@ -43,4 +43,3 @@ public final class FileNamePolicy extends FileBasedSink.FilenamePolicy {
         return prefix.getCurrentDirectory().resolve(fileName, ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
     }
 }
-

--- a/src/java/NippyCoder.java
+++ b/src/java/NippyCoder.java
@@ -10,6 +10,8 @@ import org.apache.beam.sdk.coders.CustomCoder;
 
 public final class NippyCoder extends CustomCoder<Object> {
 
+    private static final long serialVersionUID = 1L;
+
     private final IFn freeze;
     private final IFn thaw;
 

--- a/src/java/NippyCoder.java
+++ b/src/java/NippyCoder.java
@@ -8,7 +8,7 @@ import java.io.DataOutputStream;
 import java.io.DataInputStream;
 import org.apache.beam.sdk.coders.CustomCoder;
 
-public final class NippyCoder extends CustomCoder {
+public final class NippyCoder extends CustomCoder<Object> {
 
     private final IFn freeze;
     private final IFn thaw;

--- a/src/java/NippyCoder.java
+++ b/src/java/NippyCoder.java
@@ -2,10 +2,13 @@ package datasplash.coder;
 
 import clojure.java.api.Clojure;
 import clojure.lang.IFn;
+import java.io.OutputStream;
+import java.io.InputStream;
 import java.io.DataOutputStream;
 import java.io.DataInputStream;
+import org.apache.beam.sdk.coders.CustomCoder;
 
-public final class NippyCoder extends org.apache.beam.sdk.coders.CustomCoder {
+public final class NippyCoder extends CustomCoder {
 
     private final IFn freeze;
     private final IFn thaw;
@@ -17,26 +20,28 @@ public final class NippyCoder extends org.apache.beam.sdk.coders.CustomCoder {
         freeze = Clojure.var("taoensso.nippy", "freeze-to-out!");
         thaw = Clojure.var("taoensso.nippy", "thaw-from-in!");
     }
-     public void encode(Object obj, java.io.OutputStream os) {
+    public void encode(Object obj, OutputStream os) {
         DataOutputStream dos = new DataOutputStream(os);
-        try{
-        freeze.invoke(dos, obj);
+        try {
+            freeze.invoke(dos, obj);
         }
-        catch(IllegalStateException e){
-        IFn require = Clojure.var("clojure.core", "require");
-        require.invoke(Clojure.read("taoensso.nippy"));
-        this.encode(obj, os);}
+        catch (IllegalStateException e) {
+            IFn require = Clojure.var("clojure.core", "require");
+            require.invoke(Clojure.read("taoensso.nippy"));
+            this.encode(obj, os);
+        }
     }
 
-    public Object decode(java.io.InputStream is) {
+    public Object decode(InputStream is) {
         DataInputStream dis = new DataInputStream(is);
-        try{
+        try {
             return thaw.invoke(dis);
         }
-        catch(IllegalStateException e){
-       IFn require = Clojure.var("clojure.core", "require");
-       require.invoke(Clojure.read("taoensso.nippy"));
-       return this.decode(is);}
+        catch (IllegalStateException e) {
+            IFn require = Clojure.var("clojure.core", "require");
+            require.invoke(Clojure.read("taoensso.nippy"));
+            return this.decode(is);
+        }
     }
 
     public void verifyDeterministic() {

--- a/src/java/PipelineWithOptions.java
+++ b/src/java/PipelineWithOptions.java
@@ -17,7 +17,7 @@ public class PipelineWithOptions extends Pipeline {
         return pipelineOptions;
     }
 
-    public static PipelineWithOptions create (PipelineOptions options) {
+    public static PipelineWithOptions create(PipelineOptions options) {
         // Dirty hack to remain in sync with Beam
         PipelineRunner.fromOptions(options);
         return new PipelineWithOptions(options);

--- a/test/datasplash/bq_test.clj
+++ b/test/datasplash/bq_test.clj
@@ -1,10 +1,10 @@
 (ns datasplash.bq-test
-  (:require [clojure.test :refer :all]
-            [datasplash.bq :refer :all]))
+  (:require [clojure.test :refer [deftest are]]
+            [datasplash.bq :as sut]))
 
 (deftest ->time-partitioning-test
   (are [opts expected]
-    (let [tp (-> opts ->time-partitioning bean (select-keys [:type :expirationMs]))]
+    (let [tp (-> opts sut/->time-partitioning bean (select-keys [:type :expirationMs]))]
       (= expected tp))
     {} {:type "DAY" :expirationMs nil}
     {:type :day} {:type "DAY" :expirationMs nil}


### PR DESCRIPTION
Clean up and fixes required to upgrade to beam > 2.26 and (soon) nippy > 2.14.0.

Could you take a look at the three commits on the java side:

* https://github.com/ngrunwald/datasplash/commit/6a5a61df2ff92de7f5bf164dc1eaad0e5b9dff3b
* https://github.com/ngrunwald/datasplash/commit/d2fdef8f869af0d0dcbca7758ac306102329f2ae
* https://github.com/ngrunwald/datasplash/commit/d17c4ff6873f1c3f6f90a62941a23b155a0c72c0

I've tracked these down enabling the `-Xlint:unchecked` java compiler flag.
