### PR TITLE
Bump nippy version to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ** [unreleased]
 
 * resolve various java compiler warnings
+* bump dependencies including beam (2.31.0)
+* bump nippy to 3.1.1, adding alter-var-root of
+  nippy/*thaw-serializable-allowlist* to allow serializable
+  org.apache.beam.sdk.values.KV
 
 ## v0.7.2 (2021-01-07)
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [cheshire "5.10.1"]
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
-                 [com.taoensso/nippy "2.14.0"]
+                 [com.taoensso/nippy "3.1.1"]
                  [org.apache.beam/beam-sdks-java-core "2.31.0"]
                  [org.apache.beam/beam-sdks-java-io-elasticsearch "2.31.0"]
                  [org.apache.beam/beam-sdks-java-io-kafka "2.31.0"]

--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -398,6 +398,10 @@ See https://cloud.google.com/dataflow/java-sdk/JavaDoc/com/google/cloud/dataflow
   [^DoFn$ProcessContext c]
   (.output c (.element c)))
 
+(alter-var-root #'nippy/*thaw-serializable-allowlist*
+                (fn [_] (into nippy/default-thaw-serializable-allowlist
+                             #{"org.apache.beam.sdk.values.KV"})))
+
 (defn make-nippy-coder
   {:doc "Returns an instance of a CustomCoder using nippy for serialization"
    :added "0.1.0"}


### PR DESCRIPTION
As suggested by Nippy's author. See

https://github.com/ptaoussanis/nippy
