### PR TITLE
add com.google.datastore.v1.Entity to nippy allowlist

### DIFF
--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -400,7 +400,8 @@ See https://cloud.google.com/dataflow/java-sdk/JavaDoc/com/google/cloud/dataflow
 
 (alter-var-root #'nippy/*thaw-serializable-allowlist*
                 (fn [_] (into nippy/default-thaw-serializable-allowlist
-                             #{"org.apache.beam.sdk.values.KV"})))
+                             #{"org.apache.beam.sdk.values.KV"
+                               "com.google.datastore.v1.Entity"})))
 
 (defn make-nippy-coder
   {:doc "Returns an instance of a CustomCoder using nippy for serialization"


### PR DESCRIPTION
This fixes the breaking change for datastore introduced when upgrading nippy (here: https://github.com/ngrunwald/datasplash/pull/104)