### PR TITLE
fix: serialization errors on jsonista

### DIFF
--- a/src/clj/datasplash/core.clj
+++ b/src/clj/datasplash/core.clj
@@ -1354,9 +1354,9 @@ Example:
                      :label (str "read-json-file-from-"
                                  (clean-filename from))
                      :coder (or (:coder options) (make-nippy-coder)))
-         mapper-fn (json/object-mapper {:decode-key-fn key-fn})
+         with-key-fn (fn [val] (json/read-value val (json/object-mapper {:decode-key-fn key-fn})))
          decode-fn (cond
-                     key-fn #(json/read-value % mapper-fn)
+                     key-fn with-key-fn
                      :else json/read-value)]
      (pt->>
       (or (:name opts) (str "read-json-file-from-" (clean-filename from)))
@@ -1385,9 +1385,9 @@ Example:
                      :label (str "read-json-file-from-"
                                  (clean-filename from))
                      :coder (or (:coder options) (make-nippy-coder)))
-         mapper-fn (json/object-mapper {:decode-key-fn key-fn})
+         with-key-fn (fn [val] (json/read-value val (json/object-mapper {:decode-key-fn key-fn})))
          decode-fn (cond
-                     key-fn #(json/read-value % mapper-fn)
+                     key-fn with-key-fn
                      :else json/read-value)]
      (pt->>
       (or (:name opts) "read-json-files")

--- a/src/clj/datasplash/es.clj
+++ b/src/clj/datasplash/es.clj
@@ -63,13 +63,13 @@
   [hosts index type options]
   (let [safe-opts (dissoc options :name)
         key-fn    (or (get options :key-fn) false)
-        mapper-fn (json/object-mapper {:decode-key-fn key-fn})]
+        with-key-fn (fn [val] (json/read-value val (json/object-mapper {:decode-key-fn key-fn})))]
     (ds/ptransform
      :read-es-to-clj
      [^PCollection pcoll]
      (->> pcoll
           (read-es-raw hosts index type safe-opts)
-          (ds/dmap (fn [x] (json/read-value x mapper-fn)) safe-opts)))))
+          (ds/dmap with-key-fn safe-opts)))))
 
 (defn read-es
   {:doc (ds/with-opts-docstr

--- a/test/datasplash/api_test.clj
+++ b/test/datasplash/api_test.clj
@@ -87,7 +87,13 @@
         input (ds/read-json-file json-file-path {:name :read-json} p)]
     (-> (PAssert/that input)  (.containsInAnyOrder (map int test-data)))
     (is "read-json" (.getName input))
-    (ds/run-pipeline p)))
+    (ds/run-pipeline p))
+  (testing "with key-fn"
+    (let [p (ds/make-pipeline [])
+          input (ds/read-json-file json-file-path {:name :read-json-k :key-fn keyword} p)]
+      (-> (PAssert/that input)  (.containsInAnyOrder (map int test-data)))
+      (is "read-json-k" (.getName input))
+      (ds/run-pipeline p))))
 
 (deftest intra-bundle-parallelization-test
   (with-files [intra-bundle-parallelization-test]


### PR DESCRIPTION
I remembered that I had strange serialization issues like this before when using the `#()` notation, so I have fixed the issue by wrapping the function like this:

```
with-key-fn (fn [val] (json/read-value val (json/object-mapper {:decode-key-fn key-fn})))

```
The tests no longer through with this solution.