### PR TITLE
README: fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Here is the classic word count:
 Run it from the repl with:
 ```clojure
 (in-ns 'datasplash.examples)
-(compile 'datasplash.examples)
+(clojure.core/compile 'datasplash.examples)
 (-main "--input=in.txt" "--output=out.txt")
 ```
 Note that you will need to run `(compile 'datasplash.examples)` every time you


### PR DESCRIPTION
Unless I’m missing something this can’t work as-is:

> Syntax error compiling at (/tmp/form-init13710778033494800017.clj:1:1).
> Unable to resolve symbol: compile in this context