### PR TITLE
bq clean up and normalize mode type

### DIFF
--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -130,8 +130,8 @@
   (for [{:keys [type mode description] field-name :name nested-fields :fields} defs]
     (-> (TableFieldSchema.)
         (.setName (transform-keys (clean-name field-name)))
-        (.setType  (str/upper-case (name type)))
-        (cond-> mode (.setMode mode))
+        (.setType (str/upper-case (name type)))
+        (cond-> mode (.setMode (str/upper-case (name mode))))
         (cond-> description (.setDescription description))
         (cond-> nested-fields (.setFields (clj->TableFieldSchema nested-fields transform-keys))))))
 

--- a/test/datasplash/bq_schema_test.clj
+++ b/test/datasplash/bq_schema_test.clj
@@ -1,29 +1,149 @@
 (ns datasplash.bq-schema-test
   (:require
-   [clojure.test :refer [deftest is]]
+   [clj-time.coerce :as c]
+   [clojure.test :refer [are deftest is testing]]
    [datasplash.bq :as sut])
   (:import
-   (com.google.api.services.bigquery.model TableSchema)))
+   (com.google.api.services.bigquery.model TableRow TableSchema TimePartitioning)))
 
+(deftest auto-parse-val-test
+  (is (= 100 (sut/auto-parse-val "100")))
+  (is (= "abc" (sut/auto-parse-val "abc")))
+  (is (= 100 (sut/auto-parse-val 100))))
 
-(defn get-names-from-converted-schema
-  [schema]
-  (map #(.getName %) (.getFields schema)))
+(deftest table-row->clj-test
+  (let [table-row (-> {:id "30" :lang "fr" :entity-included? true :foo [{:a {:b 1}}]}
+                      sut/clj->table-row)
+        rslt (sut/table-row->clj table-row)]
+    (is (= {:id "30" :lang "fr" :entity_included true :foo '({:a {:b 1}})}
+           rslt))))
 
-(defn get-record-fields-from-converted-schema
-  [schema]
-  (first (map #(.getFields %) (filter #(= (.getType %) "RECORD") (.getFields schema)))))
+(deftest clean-name-test
+  (are [expected v] (= expected (sut/clean-name v))
+    "a" "a"
+    "is_included" "is-included?"
+    "232" 232))
 
-(deftest convert-clj-map-to-TableSchema-test
-  (let [schema [{:name "a_float" :type "FLOAT" :mode "NULLABLE"}
-                {:name "a_string" :type "STRING" :mode "NULLABLE"}
-                {:name "a_record"
-                 :type "RECORD"
-                 :mode "REPEATED"
-                 :fields
-                 [{:name "first-name" :type "STRING" :mode "NULLABLE"}
-                  {:name "last-name" :type "STRING" :mode "NULLABLE"}]}]
-        converted-schema (sut/->schema schema)]
-    (is (instance? TableSchema converted-schema))
-    (is (= (map :name schema) (get-names-from-converted-schema converted-schema)))
-    (is (= 2 (count (get-record-fields-from-converted-schema converted-schema))))))
+(deftest coerce-by-bq-val-test
+  (are [expected v] (= expected (sut/coerce-by-bq-val v))
+
+    "2010-01-01 00:00:00" (c/to-date "2010-01-01")
+    '(2 1) #{1 2}
+    "a" :a
+    "a" 'a
+    1.0 1.0
+    "1.0" "1.0"))
+
+(deftest bqize-keys-test
+  (let [table [{:id "30"
+                :long-schema? true
+                :entities {:beverage {:type "machiatto"
+                                      100 4}
+                           :snack {:type "financier"
+                                   100 24}}}]
+        rslt (sut/bqize-keys table)]
+    (is (= [{"id" "30"
+            "long_schema" true
+             "entities" {"beverage" {"type" "machiatto"
+                                     "100" 4}
+                         "snack" {"type" "financier"
+                                  "100" 24}}}]
+           rslt))))
+
+(deftest clj->table-row-test
+  (let [rslt (-> {:id "30" :lang "fr" :entity-included? true}
+                 sut/clj->table-row)]
+    (is (instance? TableRow rslt))
+    (is (= {"id" "30" "lang" "fr" "entity_included" true}
+           rslt))))
+
+(deftest ->schema-test
+  (testing "nominal case"
+    (let [schema [{:name "a_float" :type "FLOAT" :mode "NULLABLE"}
+                  {:name "another_float" :type :float :mode "NULLABLE"}
+                  {:name "a_string" :type "STRING" :mode :nullable}
+                  {:name "a_record"
+                   :type "RECORD"
+                   :mode "REPEATED"
+                   :fields
+                   [{:name "first-name" :type "STRING" :mode :required}
+                    {:name "last-name" :type "STRING" :mode "REQUIRED"}
+                    {:name "dislikes-bechamel?" :type :bool :mode :required}]}]
+
+          expected {"fields" [{"name" "a_float" "type" "FLOAT" "mode" "NULLABLE"}
+                              {"name" "another_float" "type" "FLOAT" "mode" "NULLABLE"}
+                              {"name" "a_string" "type" "STRING" "mode" "NULLABLE"}
+                              {"name" "a_record"
+                               "type" "RECORD"
+                               "mode" "REPEATED"
+                               "fields" [{"name" "first_name" "type" "STRING" "mode" "REQUIRED"}
+                                         {"name" "last_name" "type" "STRING" "mode" "REQUIRED"}
+                                         {"name" "dislikes_bechamel" "type" "BOOL" "mode" "REQUIRED"}]}]}
+          rslt (sut/->schema schema)]
+      (is (instance? TableSchema rslt))
+      (is (= expected rslt))))
+
+  (testing "optional values:"
+    (let [schema {:name "a" :type :string}]
+      (testing "description"
+        (let [test-schema (assoc schema :description "desc")
+              expected {"fields" [{"name" "a"
+                                   "type" "STRING"
+                                   "description" "desc"}]}
+              rslt (sut/->schema [test-schema])]
+          (is (= expected
+                 rslt)))))))
+
+(deftest ->time-partitioning-test
+  (testing "nominal case"
+    (let [expected {"type" "DAY"}
+          rslt (sut/->time-partitioning {:type :day})]
+      (is (instance? TimePartitioning rslt))
+      (is (= expected
+             rslt)
+          "with type opt")
+
+      (let [rslt (sut/->time-partitioning {})]
+        (is (= expected
+               rslt)
+            "default to DAY partitioning"))))
+
+  (testing "optional values:"
+    (testing "expiration ms"
+      (let [expected {"type" "DAY" "expirationMs" 400}
+            rslt (sut/->time-partitioning {:expiration-ms 400})]
+        (is (= expected
+               rslt)
+            "int expiration is added"))
+
+      (let [expected {"type" "DAY"}]
+        (is (= expected (sut/->time-partitioning {:expiration-ms "44"}))
+            "not int expiration is ignored")
+        (is (= expected (sut/->time-partitioning {:expiration-ms 43.2}))
+            "float expiration is ignored")))
+
+    (testing "field"
+      (let [expected {"type" "DAY" "field" "a field"}
+            rslt (sut/->time-partitioning {:field "a field"})]
+        (is (= expected
+               rslt)
+            "string field is added"))
+
+      (let [expected {"type" "DAY"}
+            rslt (sut/->time-partitioning {:field 123})]
+        (is (= expected
+               rslt)
+            "not string is ignored")))
+
+    (testing "require-partition-filter"
+      (let [expected {"type" "DAY" "requirePartitionFilter" true}
+            rslt (sut/->time-partitioning {:require-partition-filter true})]
+        (is (= expected
+               rslt)
+            "when true is added"))
+
+      (let [expected {"type" "DAY"}
+            rslt (sut/->time-partitioning {:require-partition-filter 1})]
+        (is (= expected
+               rslt)
+            "non-boolean value is ignored")))))


### PR DESCRIPTION
* added more tests to bq ns
* now normalizing bq table schema mode to allow us to use `:required`, `:record`, `:nullable`
* define specs to validate table schema values for mode & type, and time-partitioning types as per BQ docs
* add initial support for setMaxLength, setPrecision, setScale
* general cleanup, etc