### PR TITLE
Add a keep ptransform

### DIFF
--- a/src/clj/datasplash/api.clj
+++ b/src/clj/datasplash/api.clj
@@ -1,5 +1,5 @@
 (ns datasplash.api
-  (:refer-clojure :exclude [map filter mapcat group-by
+  (:refer-clojure :exclude [map filter keep mapcat group-by
                             distinct flatten concat juxt identity
                             max min count frequencies key val partition-by
                             cond->> ->>])
@@ -32,6 +32,7 @@
 (intern *ns* (with-meta 'map (meta #'dt/dmap)) @#'dt/dmap)
 (intern *ns* (with-meta 'map-kv (meta #'dt/map-kv)) @#'dt/map-kv)
 (intern *ns* (with-meta 'filter (meta #'dt/dfilter)) @#'dt/dfilter)
+(intern *ns* (with-meta 'keep (meta #'dt/dkeep)) @#'dt/dkeep)
 (intern *ns* (with-meta 'mapcat (meta #'dt/dmapcat)) @#'dt/dmapcat)
 (intern *ns* (with-meta 'with-keys (meta #'dt/with-keys)) @#'dt/with-keys)
 (intern *ns* (with-meta 'group-by-key (meta #'dt/group-by-key)) @#'dt/group-by-key)

--- a/test/datasplash/api_test.clj
+++ b/test/datasplash/api_test.clj
@@ -505,6 +505,35 @@
     (let [status (sut/wait-pipeline-result (sut/run-pipeline p))]
       (is (= :done status)))))
 
+(deftest keep-test
+  (testing "it keeps all elements"
+    (let [values [false true false]
+          input (sut/generate-input values (sut/make-pipeline []))
+          rslt (sut/keep identity {:name :keep-test1} input)]
+
+      (.containsInAnyOrder (PAssert/that rslt) values)
+
+      (is (str/starts-with? (.getName rslt) "keep-test1"))
+      (is (= :done (sut/wait-pipeline-result (sut/run-pipeline input))))))
+
+  (testing "it discards all elements"
+    (let [input (sut/generate-input ["a" "b" "c"] (sut/make-pipeline []))
+          rslt (sut/keep parse-long {:name :keep-test2} input)]
+
+      (.empty (PAssert/that rslt))
+
+      (is (str/starts-with? (.getName rslt) "keep-test2"))
+      (is (= :done (sut/wait-pipeline-result (sut/run-pipeline input))))))
+
+  (testing "it keeps some elements"
+    (let [input (sut/generate-input ["a" "1" "b"] (sut/make-pipeline []))
+          rslt (sut/keep parse-long {:name :keep-test3} input)]
+
+      (.containsInAnyOrder (PAssert/that rslt) [1])
+
+      (is (str/starts-with? (.getName rslt) "keep-test3"))
+      (is (= :done (sut/wait-pipeline-result (sut/run-pipeline input)))))))
+
 (deftest with-keys-test
   (tio/with-tempdir [tmp-dir]
     (let [p (sut/make-pipeline [])


### PR DESCRIPTION
Looking at our codebase, I can see a lot of `(d/map ...)` followed by `(d/filter some? ...)`. Its seems that a `keep` ptransform may be useful.

Beware the `dkeep` implementation only discards null values.