### PR TITLE
Add test helpers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,12 @@
                                   [com.oscaro/tools-io "0.3.29"]]
                    :source-paths ["test"]
                    :resource-paths ["test/resources"]
-                   :aot  [clojure.tools.logging.impl datasplash.api-test datasplash.examples clj-time.core datasplash.core clojure.tools.reader.reader-types]}
+                   :aot [clj-time.core
+                         clojure.tools.logging.impl
+                         clojure.tools.reader.reader-types
+                         datasplash.api-test
+                         datasplash.core
+                         datasplash.examples
+                         datasplash.testing.assert-test]}
              :uberjar {:aot :all}}
   :main datasplash.examples)

--- a/resources/clj-kondo.exports/datasplash/datasplash/config.edn
+++ b/resources/clj-kondo.exports/datasplash/datasplash/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {datasplash.api/->> clojure.core/->>
+           datasplash.api/pt->> clojure.core/->>
+           datasplash.options/defoptions clojure.core/def
+           datasplash.testing/with-test-pipeline clojure.core/let}}

--- a/src/clj/datasplash/testing.clj
+++ b/src/clj/datasplash/testing.clj
@@ -1,0 +1,56 @@
+(ns datasplash.testing
+  "Namespace of various utilities to test pipelines."
+  (:require
+   [datasplash.core :as ds])
+  (:import
+   (org.apache.beam.sdk.testing TestPipeline)))
+
+(set! *warn-on-reflection* true)
+
+(defn generate
+  "Like `datasplash.api/generate-input` but uses a unique name.
+   Useful in TestPipeline where ptranforms **cannot** have the same name."
+  ([p]
+   (generate [] p))
+  ([values p]
+   (generate values nil p))
+  ([values options p]
+   (ds/generate-input values
+                      (cond-> options
+                        (nil? (:name options))
+                        (assoc :name (str "generate-" (System/nanoTime))))
+                      p)))
+
+(defn test-pipeline
+  "Returns a TestPipeline."
+  ^TestPipeline []
+  (-> (TestPipeline/create)
+      (.enableAbandonedNodeEnforcement true)))
+
+(defn run-test-pipeline
+  "Runs a Pipeline and waits until it finishes to assert execution state."
+  [topology]
+  (let [state (ds/wait-pipeline-result (ds/run-pipeline topology))
+        ;; dynamically load `clojure.test` to avoid dependency in main profile.
+        do-report (requiring-resolve 'clojure.test/do-report)]
+    (if (= :done state)
+      (do-report {:type :pass})
+      (do-report {:type :fail :message "Wrong pipeline state"
+                  :expected :done :actual state}))
+    state))
+
+(defmacro with-test-pipeline
+  "Syntactic sugar to run a test pipeline.
+   Use bindings vector to initialize options and create a pipeline.
+   The pipeline creation must be the last binding.
+
+   ```
+   (with-test-pipeline [p (test-pipeline)]
+     (generate [:a :b :c] p))
+   ```"
+  [bindings & body]
+  (assert (vector? bindings) "a vector for its binding")
+  (assert (even? (count bindings)) "an even number of forms in binding vector")
+  `(let ~bindings
+     ~@body
+     (run-test-pipeline ~(nth bindings (- (count bindings) 2)))))

--- a/src/clj/datasplash/testing/assert.clj
+++ b/src/clj/datasplash/testing/assert.clj
@@ -1,0 +1,105 @@
+(ns datasplash.testing.assert
+  "Namespace to expose `PAssert` based matchers to test pipelines.
+   Because `PAssert` is made to be used with JUnit, assertions will only raise `AssertionError`."
+  (:require
+   [datasplash.core :as ds])
+  (:import
+   (datasplash.testing PredicateMatcher)
+   (org.apache.beam.sdk.testing PAssert
+                                PAssert$IterableAssert
+                                PAssert$SingletonAssert)
+   (org.apache.beam.sdk.transforms SerializableFunction)
+   (org.hamcrest MatcherAssert)))
+
+(set! *warn-on-reflection* true)
+
+(defn as-iterable
+  "Returns an `IterableAssert` for a given PCollection."
+  ^PAssert$IterableAssert
+  [pcoll]
+  (PAssert/that pcoll))
+
+(defn as-singleton-iterable
+  "Returns an `IterableAssert` for a given PCollection.
+   The provided PCollection must use an `IterableCoder` and have one element."
+  ^PAssert$IterableAssert
+  [pcoll]
+  (PAssert/thatSingletonIterable pcoll))
+
+(defn as-flattened
+  "Returns an `IterableAssert` for a flattened PCollectionList."
+  ^PAssert$IterableAssert
+  [pcoll-list]
+  (PAssert/thatFlattened pcoll-list))
+
+(defn as-singleton
+  "Returns a `SingletonAssert` for a given **one element** PCollection."
+  ^PAssert$SingletonAssert
+  [pcoll]
+  (PAssert/thatSingleton pcoll))
+
+(defn as-map
+  "Returns a `SingletonAssert` for a given KV PCollection coerce as a map."
+  ^PAssert$SingletonAssert
+  [kv-pcoll]
+  (PAssert/thatMap kv-pcoll))
+
+(defn as-multimap
+  "Returns a `SingletonAssert` for a given KV PCollection coerce as a multimap."
+  ^PAssert$SingletonAssert
+  [kv-pcoll]
+  (PAssert/thatMultimap kv-pcoll))
+
+(defprotocol AssertContainsOnly
+  (contains-only
+    [this expected]
+    "Asserts element only contains expected **in any order**."))
+
+(defprotocol AssertIsEmpty
+  (is-empty [this]
+    "Asserts element is empty."))
+
+(defprotocol AssertEquals
+  (equals-to [this expected]
+    "Asserts element is equal to expected."))
+
+(defprotocol AssertNotEquals
+  (not-equals-to [this expected]
+    "Asserts element is not equal to expected value."))
+
+(defprotocol AssertSatisfies
+  (satisfies [this pred]
+    "Asserts element against a predicate function."))
+
+(defn- satisfies-sfn
+  ^SerializableFunction
+  [pred]
+  (ds/sfn
+   (fn [v]
+     (MatcherAssert/assertThat v (PredicateMatcher/satisfies pred)))))
+
+(extend-type PAssert$IterableAssert
+  AssertContainsOnly
+  (contains-only [this ^Iterable expected]
+    (.containsInAnyOrder this expected))
+
+  AssertIsEmpty
+  (is-empty [this]
+    (.empty this))
+
+  AssertSatisfies
+  (satisfies [this pred]
+    (.satisfies this (satisfies-sfn pred))))
+
+(extend-type PAssert$SingletonAssert
+  AssertEquals
+  (equals-to [this expected]
+    (.isEqualTo this expected))
+
+  AssertNotEquals
+  (not-equals-to [this expected]
+    (.notEqualTo this expected))
+
+  AssertSatisfies
+  (satisfies [this pred]
+    (.satisfies this (satisfies-sfn pred))))

--- a/src/java/PredicateMatcher.java
+++ b/src/java/PredicateMatcher.java
@@ -1,0 +1,38 @@
+package datasplash.testing;
+
+import clojure.java.api.Clojure;
+import clojure.lang.IFn;
+import clojure.lang.RT;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+public class PredicateMatcher<T> extends BaseMatcher<T> {
+    private final IFn pred;
+
+    protected PredicateMatcher(IFn pred) {
+        this.pred = pred;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+        return RT.booleanCast(pred.invoke(o));
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("satisfies predicate fonction: "
+                + pred.getClass().getName());
+    }
+
+    @Override
+    public void describeMismatch(Object item, Description description) {
+        description.appendText("f(")
+            .appendValue(item)
+            .appendText(") was falsy");
+    }
+
+    public static Matcher<Object> satisfies(IFn pred) {
+        return new PredicateMatcher<Object>(pred);
+    }
+}

--- a/test/datasplash/testing/assert_test.clj
+++ b/test/datasplash/testing/assert_test.clj
@@ -1,0 +1,164 @@
+(ns datasplash.testing.assert-test
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is testing]]
+   [datasplash.core :as ds]
+   [datasplash.testing :as dt]
+   [datasplash.testing.assert :as sut])
+  (:import
+   (org.apache.beam.sdk.coders IterableCoder)
+   (org.apache.beam.sdk.values PCollectionList)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private iterable-coder
+  (IterableCoder/of (ds/make-nippy-coder)))
+
+(defn- pcoll-list
+  [colls p]
+  (PCollectionList/of ^Iterable (mapv #(dt/generate % p) colls)))
+
+(defn- kv-pcoll
+  [kvs p]
+  (ds/map-kv #(vector (first %) (second %))
+             {:name (str "kv-pcoll-map-" (System/nanoTime))}
+             (dt/generate kvs p)))
+
+(deftest as-iterable-test
+  (testing "Assert iterable equals"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (dt/generate [:a :b :c] p)
+          (sut/as-iterable)
+          (sut/contains-only [:a :b :c]))
+
+      (-> (dt/generate [[:a :b :c]] {:coder iterable-coder} p)
+          (sut/as-singleton-iterable)
+          (sut/contains-only [:a :b :c]))
+
+      (-> (pcoll-list [[:a :b] [:c]] p)
+          (sut/as-flattened)
+          (sut/contains-only [:a :b :c]))))
+
+  (testing "Assert iterable equals failure!"
+    (is (thrown? AssertionError
+                 (dt/with-test-pipeline [p (dt/test-pipeline)]
+                   (-> (sut/as-iterable (dt/generate [1 2] p))
+                       (sut/contains-only [:ko]))))))
+
+  (testing "Assert iterable is empty"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (dt/generate p)
+          (sut/as-iterable)
+          (sut/is-empty))
+
+      (-> (dt/generate [[]] {:coder iterable-coder} p)
+          (sut/as-singleton-iterable)
+          (sut/is-empty))
+
+      (-> (pcoll-list [[]] p)
+          (sut/as-flattened)
+          (sut/is-empty))))
+
+  (testing "Assert iterable is empty failure!"
+    (is (thrown? AssertionError
+                 (dt/with-test-pipeline [p (dt/test-pipeline)]
+                   (-> (sut/as-iterable (dt/generate [1 2] p))
+                       (sut/is-empty))))))
+
+  (testing "Assert iterable satisfies"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (dt/generate [:a :b :c] p)
+          (sut/as-iterable)
+          (sut/satisfies #(set/superset? (set %) #{:a :b})))
+
+      (-> (dt/generate [[:a :b :c]] {:coder iterable-coder} p)
+          (sut/as-singleton-iterable)
+          (sut/satisfies #(set/superset? (set %) #{:a :b})))
+
+      (-> (pcoll-list [[:a :b] [:c]] p)
+          (sut/as-flattened)
+          (sut/satisfies #(set/superset? (set %) #{:a :b})))))
+
+  (testing "Assert iterable satisfies failure!"
+    (is (thrown? AssertionError
+                 (dt/with-test-pipeline [p (dt/test-pipeline)]
+                   (-> (sut/as-iterable (dt/generate p))
+                       (sut/satisfies seq))))))
+
+  (testing "Assert iterable matchers composition"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (sut/as-iterable (dt/generate p))
+          (sut/is-empty)
+          (sut/contains-only [])
+          (sut/satisfies empty?)))))
+
+(deftest as-singleton-test
+  (testing "Assert singleton equals"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (dt/generate [[1 2 3]] p)
+          (sut/as-singleton)
+          (sut/equals-to [1 2 3]))
+
+      (-> (kv-pcoll [[:a 1] [:b 2]] p)
+          (sut/as-map)
+          (sut/equals-to {:a 1 :b 2}))
+
+      (-> (kv-pcoll [[:a 1] [:b 2]] p)
+          (sut/as-multimap)
+          (sut/equals-to {:a [1] :b [2]}))))
+
+  (testing "Assert singleton equals failure!"
+    (is (thrown? AssertionError
+                 (dt/with-test-pipeline [p (dt/test-pipeline)]
+                   (-> (dt/generate [42] p)
+                       (sut/as-singleton)
+                       (sut/equals-to 77))))))
+
+  (testing "Assert singleton not equals"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (dt/generate [[1 2 3]] p)
+          (sut/as-singleton)
+          (sut/not-equals-to [2 3]))
+
+      (-> (kv-pcoll [[:a 1] [:b 2]] p)
+          (sut/as-map)
+          (sut/not-equals-to {:a 2 :b 2}))
+
+      (-> (kv-pcoll [[:a 1] [:b 2] [:a 3]] p)
+          (sut/as-multimap)
+          (sut/not-equals-to {:a [1] :b [2]}))))
+
+  (testing "Assert singleton not equals failure!"
+    (is (thrown? AssertionError
+                 (dt/with-test-pipeline [p (dt/test-pipeline)]
+                   (-> (dt/generate [42] p)
+                       (sut/as-singleton)
+                       (sut/not-equals-to 42))))))
+
+  (testing "Assert singleton satisfies"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (dt/generate [[1 2 3]] p)
+          (sut/as-singleton)
+          (sut/satisfies #(= 3 (count %))))
+
+      (-> (kv-pcoll [[:a 1] [:b 2]] p)
+          (sut/as-map)
+          (sut/satisfies #(even? (:b %))))
+
+      (-> (kv-pcoll [[:a 1] [:b 2] [:a 3]] p)
+          (sut/as-multimap)
+          (sut/satisfies #(= #{1 3} (set (:a %)))))))
+
+  (testing "Assert singleton satisfies failure!"
+    (is (thrown? AssertionError
+                 (dt/with-test-pipeline [p (dt/test-pipeline)]
+                   (-> (dt/generate [42] p)
+                       (sut/as-singleton)
+                       (sut/satisfies odd?))))))
+
+  (testing "Assert singleton matchers composition"
+    (dt/with-test-pipeline [p (dt/test-pipeline)]
+      (-> (sut/as-singleton (dt/generate [42] p))
+          (sut/equals-to 42)
+          (sut/not-equals-to 77)
+          (sut/satisfies even?)))))


### PR DESCRIPTION
Hello,

Here is a PR to add a namespace to expose test helpers wrapping `PAssert`.

## 1st commit: New testing namespace

  Pro:
  - Writing test is shorter
  - We can coerce a pcoll to various shape before testing: Iterable, Map, Mutimap, Singleton obj
  - Writing test, we can see what is inside a pcoll at runtime with a matcher like `(dt/satisfies tap>)`

  Cons:
  - `PAssert` raises `AssertionError` and gives only a text message about what went wrong

## 2nd commit: Test api rewrite

A complete rewrite of `test_api.clj` to use those new helpers. We reduced the file size by a third and tests run a little bit faster.

## 3nd commit: Open questions before merge

The project has a clj-kondo config for developers, but it seems that this file is more a personal configuration file for whoever uses clj-kondo. Do we want to keep it or let developers do as they please?

Regards
