### PR TITLE
updates to BQ ns : new schema types, support for set collation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 * Bump beam to 2.56.0
+* update of BQ schema spec types to now allow `:json` and `:range`
+* add support to set collation for STRING type
 
 ### Fixed
 

--- a/test/datasplash/bq_test.clj
+++ b/test/datasplash/bq_test.clj
@@ -132,6 +132,15 @@
           (is (= expected
                  rslt))))
 
+      (testing "collation"
+        (let [test-schema (assoc schema :collation "und:ci'")
+              expected {"fields" [{"name" "a"
+                                   "type" "STRING"
+                                   "collation" "und:ci'"}]}
+              rslt (sut/->schema [test-schema])]
+          (is (= expected
+                 rslt))))
+
       (testing "variable length options"
         (let [test-schema (assoc schema :maxLength 200)
               expected {"fields" [{"name" "a"


### PR DESCRIPTION
* enable set collation for string types
* add json and range types to spec for schema validation
* split table-field spec defs by type