### PR TITLE
Add temp-dataset and temp-project options in BQ read

### DIFF
--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -35,7 +35,7 @@
         ptrans (cond (and temp-project temp-dataset)
                        (.withQueryTempProjectAndDataset ptrans temp-project temp-dataset)
                      temp-dataset
-                       (.withQueryTempDataset ptrans temp-project temp-dataset)
+                       (.withQueryTempDataset ptrans temp-dataset)
                      (and temp-project (not temp-dataset))
                        (throw (ex-info
                                 "Error with options of read-bq-table, temp-project requires temp-dataset to be set"

--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -22,16 +22,26 @@
    (org.apache.beam.sdk.values PBegin PCollection)))
 
 (defn read-bq-raw
-  [{:keys [query table standard-sql? query-location] :as options} p]
+  [{:keys [query table standard-sql? query-location temp-project temp-dataset] :as options} p]
   (let [opts (assoc options :label :read-bq-table-raw)
         ptrans (cond
                  query (cond-> (.fromQuery (BigQueryIO/readTableRows) query)
-                         standard-sql? (.usingStandardSql)
-                         query-location (.withQueryLocation query-location))
+                               standard-sql? (.usingStandardSql)
+                               query-location (.withQueryLocation query-location))
                  table (.from (BigQueryIO/readTableRows) table)
                  :else (throw (ex-info
                                "Error with options of read-bq-table, should specify one of :table or :query"
-                               {:options options})))]
+                               {:options options})))
+        ptrans (cond (and temp-project temp-dataset)
+                       (.withQueryTempProjectAndDataset ptrans temp-project temp-dataset)
+                     temp-dataset
+                       (.withQueryTempDataset ptrans temp-project temp-dataset)
+                     (and temp-project (not temp-dataset))
+                       (throw (ex-info
+                                "Error with options of read-bq-table, temp-project requires temp-dataset to be set"
+                                {:options options}))
+                    :else ptrans)]
+
     (-> p
         (cond-> (instance? Pipeline p) (PBegin/in))
         (ds/apply-transform

--- a/src/clj/datasplash/bq.clj
+++ b/src/clj/datasplash/bq.clj
@@ -26,21 +26,19 @@
   (let [opts (assoc options :label :read-bq-table-raw)
         ptrans (cond
                  query (cond-> (.fromQuery (BigQueryIO/readTableRows) query)
-                               standard-sql? (.usingStandardSql)
-                               query-location (.withQueryLocation query-location))
+                         standard-sql? (.usingStandardSql)
+                         query-location (.withQueryLocation query-location))
                  table (.from (BigQueryIO/readTableRows) table)
                  :else (throw (ex-info
                                "Error with options of read-bq-table, should specify one of :table or :query"
                                {:options options})))
-        ptrans (cond (and temp-project temp-dataset)
-                       (.withQueryTempProjectAndDataset ptrans temp-project temp-dataset)
-                     temp-dataset
-                       (.withQueryTempDataset ptrans temp-dataset)
-                     (and temp-project (not temp-dataset))
-                       (throw (ex-info
-                                "Error with options of read-bq-table, temp-project requires temp-dataset to be set"
-                                {:options options}))
-                    :else ptrans)]
+        ptrans (cond
+                 (and temp-project temp-dataset) (.withQueryTempProjectAndDataset ptrans temp-project temp-dataset)
+                 temp-dataset (.withQueryTempDataset ptrans temp-dataset)
+                 (and temp-project (not temp-dataset)) (throw (ex-info
+                                                               "Error with options of read-bq-table, temp-project requires temp-dataset to be set"
+                                                               {:options options}))
+                 :else ptrans)]
 
     (-> p
         (cond-> (instance? Pipeline p) (PBegin/in))


### PR DESCRIPTION
These options allow us to define where Dataflow will write temporary BigQuery table during its processing instead of letting it create a lot of temporary datasets (which also requires elevated rights).