### PR TITLE
bump beam to 2.64.0, other deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Bump beam to 2.64.0.
 * Bump slf4j to 2.x.
 * Bump charred to 1.037.
+* Bump nippy to 3.5.0.
 
 ### Fixed
 * Fix bug on Elasticsearch write when using id, type & index functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+* Bump beam to 2.64.0.
 
 ### Fixed
 * Fix bug on Elasticsearch write when using id, type & index functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 * Bump beam to 2.64.0.
 * Bump slf4j to 2.x.
+* Bump charred to 1.037.
 
 ### Fixed
 * Fix bug on Elasticsearch write when using id, type & index functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 * Bump beam to 2.64.0.
+* Bump slf4j to 2.x.
 
 ### Fixed
 * Fix bug on Elasticsearch write when using id, type & index functions.

--- a/project.clj
+++ b/project.clj
@@ -28,9 +28,9 @@
                  ;; required as of beam 2.55.0
                  [junit/junit "4.13.2"]
 
-                 ;; as of 2.53.0, beam is no longer compatible with slf4j-2. See:
-                 ;; https://cwiki.apache.org/confluence/display/BEAM/Java+Tips
-                 [org.slf4j/slf4j-api "1.7.36"]]
+                 ;; as of 2.64.0, beam is now compatibla with slf4j 2.x. See
+                 ;; https://github.com/apache/beam/pull/33574
+                 [org.slf4j/slf4j-api "2.0.17"]]
   :pedantic? false
   :target-path "target/%s/"
   :source-paths ["src/clj"]
@@ -46,7 +46,7 @@
                     [io.airlift/aircompressor "2.0.2"]
                     [com.facebook.presto.hadoop/hadoop-apache2 "3.2.0-1"]
                     ;; compatible log implementation for local runs
-                    [org.slf4j/slf4j-simple "1.7.36"]]
-                   :plugins [[dev.weavejester/lein-cljfmt "0.13.0"]]}
+                    [org.slf4j/slf4j-simple "2.0.17"]]
+                   :plugins [[dev.weavejester/lein-cljfmt "0.13.1"]]}
              :test {:source-paths ["test"]
                     :aot :all}})

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/math.combinatorics "0.3.0"]
                  [org.clojure/tools.logging "1.3.0"]
 
-                 [com.cnuernber/charred "1.036"]
+                 [com.cnuernber/charred "1.037"]
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
 

--- a/project.clj
+++ b/project.clj
@@ -13,12 +13,15 @@
 
                  [com.taoensso/nippy "3.4.2"]
 
-                 [org.apache.beam/beam-sdks-java-core "2.63.0"]
-                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.63.0"]
-                 [org.apache.beam/beam-sdks-java-io-kafka "2.63.0"]
-                 [org.apache.beam/beam-runners-direct-java "2.63.0"]
-                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.63.0"]
-                 [org.apache.beam/beam-runners-core-java "2.63.0"]
+                 [org.apache.beam/beam-sdks-java-core "2.64.0"]
+                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.64.0"]
+                 [org.apache.beam/beam-sdks-java-io-kafka "2.64.0"]
+                 [org.apache.beam/beam-runners-direct-java "2.64.0"]
+                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.64.0"]
+                 [org.apache.beam/beam-runners-core-java "2.64.0"]
+                 ;; org.apache.kafka/kafka-clients is required it in
+                 ;; the kafka ns. Match the version provided by beam. See:
+                 ;; https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-kafka
                  [org.apache.kafka/kafka-clients "2.4.1"]
                  [superstring "3.2.1"]
 
@@ -38,7 +41,7 @@
                    [[com.oscaro/tools-io "0.3.40"]
                     ;; include compression libs for tests
                     ;;  zstd
-                    [com.github.luben/zstd-jni "1.5.6-10"]
+                    [com.github.luben/zstd-jni "1.5.7-2"]
                     ;;  lzo & lzop
                     [io.airlift/aircompressor "2.0.2"]
                     [com.facebook.presto.hadoop/hadoop-apache2 "3.2.0-1"]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
 
-                 [com.taoensso/nippy "3.4.2"]
+                 [com.taoensso/nippy "3.5.0"]
 
                  [org.apache.beam/beam-sdks-java-core "2.64.0"]
                  [org.apache.beam/beam-sdks-java-io-elasticsearch "2.64.0"]

--- a/src/clj/datasplash/kafka.clj
+++ b/src/clj/datasplash/kafka.clj
@@ -107,10 +107,10 @@
 ```
     {:payload   \"Deserialized with `value-deserializer`\"
      :key       \"Deserialized with `key-deserializer`\"
-     :offset    \"...\"     
+     :offset    \"...\"
      :partition \"...\"
-     :timestamp \"...\"   
-     :topic     \"...\"   
+     :timestamp \"...\"
+     :topic     \"...\"
      :headers   \"A map of `{key values}` of `Header` (https://www.javadoc.io/static/org.apache.kafka/kafka-clients/1.0.0/org/apache/kafka/common/header/Header.html)\"}
 ```
 


### PR DESCRIPTION
* Bump beam to 2.64.0.
* Bump slf4j to 2.x.
* Bump charred to 1.037.
* Bump nippy to 3.5.0.
