### PR TITLE
Minor fixes

### DIFF
--- a/src/clj/datasplash/es.clj
+++ b/src/clj/datasplash/es.clj
@@ -96,7 +96,7 @@ Examples:
   (merge
    es-connection-schema
    {:max-batch-size       {:docstr "Specify the max number of documents in a bulk. Default to 1000"
-                           :action (fn [^ElasticsearchIO$Write transform ^Long b] (.withMaxBatchSizeBytes transform b))}
+                           :action (fn [^ElasticsearchIO$Write transform ^Long b] (.withMaxBatchSize transform b))}
     :max-batch-size-bytes {:docstr "Specify the max number of bytes in a bulk. Default to 5MB"
                            :action (fn [^ElasticsearchIO$Write transform ^Long b] (.withMaxBatchSizeBytes transform b))}
     :retry-configuration  {:docstr "Creates RetryConfiguration for ElasticsearchIO with provided max-attempts, max-durations and exponential backoff based retries"

--- a/src/clj/datasplash/pubsub.clj
+++ b/src/clj/datasplash/pubsub.clj
@@ -25,7 +25,7 @@
    Payload must be a string and attributes a map."
   [{:keys [payload attributes]}]
   (let [attributes-map (->> attributes
-                            (ds/dmap (fn [k v] [(if (keyword? k) (name k) (str k)) (str v)]))
+                            (map (fn [[k v]] [(if (keyword? k) (name k) (str k)) (str v)]))
                             (into {}))]
     (PubsubMessage. (.getBytes payload StandardCharsets/UTF_8) attributes-map)))
 


### PR DESCRIPTION
A few tweaks I discovered while experimenting with Datasplash.

- switch a use of `dmap` to `map` as it's in regular clojure code and not part of a pipeline
- fix a schema action in `es.clj` that was calling the wrong underlying Java function