### PR TITLE
bump beam 2.71.0, other deps

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: 8
 
     - name: Install clojure tools
-      uses: DeLaGuardo/setup-clojure@13.4
+      uses: DeLaGuardo/setup-clojure@13.5.2
       with:
         # Install just one or all simultaneously
         # The value must indicate a particular version of the tool, or use 'latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 * bump beam to 2.71.0
+* bump tools.logging to 1.3.1, tools-io to 0.3.42
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * bump beam to 2.71.0
 * bump tools.logging to 1.3.1, tools-io to 0.3.42
 * bump clj to 1.12.4
+* bump math.combinatorics to 0.3.2
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+* bump beam to 2.71.0
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 * bump beam to 2.71.0
 * bump tools.logging to 1.3.1, tools-io to 0.3.42
+* bump clj to 1.12.4
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See Apache Beam [Compression enum][] for details.
 
 ## License
 
-Copyright © 2015-2025 Oscaro.com
+Copyright © 2015-2026 Oscaro.com
 
 Distributed under the Eclipse Public License either version 1.0 or (at your
 option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.12.2"]
                  [org.clojure/math.combinatorics "0.3.0"]
-                 [org.clojure/tools.logging "1.3.0"]
+                 [org.clojure/tools.logging "1.3.1"]
 
                  [com.cnuernber/charred "1.037"]
                  [clj-stacktrace "0.2.8"]
@@ -38,10 +38,10 @@
   :javac-options ["-target" "1.8" "-source" "1.8" "-Xlint:unchecked"]
   :deploy-repositories {"releases" {:url "https://repo.clojars.org"}}
   :profiles {:dev {:dependencies
-                   [[com.oscaro/tools-io "0.3.41"]
+                   [[com.oscaro/tools-io "0.3.42"]
                     ;; include compression libs for tests
                     ;;  zstd
-                    [com.github.luben/zstd-jni "1.5.7-4"]
+                    [com.github.luben/zstd-jni "1.5.7-6"]
                     ;;  lzo & lzop
                     [io.airlift/aircompressor "2.0.2"]
                     [com.facebook.presto.hadoop/hadoop-apache2 "3.2.0-1"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ngrunwald/datasplash"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.12.2"]
+  :dependencies [[org.clojure/clojure "1.12.4"]
                  [org.clojure/math.combinatorics "0.3.0"]
                  [org.clojure/tools.logging "1.3.1"]
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.12.4"]
-                 [org.clojure/math.combinatorics "0.3.0"]
+                 [org.clojure/math.combinatorics "0.3.2"]
                  [org.clojure/tools.logging "1.3.1"]
 
                  [com.cnuernber/charred "1.037"]

--- a/project.clj
+++ b/project.clj
@@ -13,12 +13,12 @@
 
                  [com.taoensso/nippy "3.6.0"]
 
-                 [org.apache.beam/beam-sdks-java-core "2.67.0"]
-                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.67.0"]
-                 [org.apache.beam/beam-sdks-java-io-kafka "2.67.0"]
-                 [org.apache.beam/beam-runners-direct-java "2.67.0"]
-                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.67.0"]
-                 [org.apache.beam/beam-runners-core-java "2.67.0"]
+                 [org.apache.beam/beam-sdks-java-core "2.71.0"]
+                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.71.0"]
+                 [org.apache.beam/beam-sdks-java-io-kafka "2.71.0"]
+                 [org.apache.beam/beam-runners-direct-java "2.71.0"]
+                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.71.0"]
+                 [org.apache.beam/beam-runners-core-java "2.71.0"]
                  ;; org.apache.kafka/kafka-clients is required it in
                  ;; the kafka ns. Match the version provided by beam. See:
                  ;; https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-kafka


### PR DESCRIPTION
@kawas44 👋 

* bump beam to 2.71.0
* bump tools.logging to 1.3.1, tools-io to 0.3.42
* bump clj to 1.12.4
* bump math.combinatorics to 0.3.2
