### PR TITLE
fix: ES id-fn option uses unserializable fn

### DIFF
--- a/src/clj/datasplash/es.clj
+++ b/src/clj/datasplash/es.clj
@@ -94,7 +94,7 @@ Examples:
 
 (defn- ->ExtractKeyfn ^ExtractKeyFn
   [doc-key-fn]
-  (ExtractKeyFn. (comp doc-key-fn (charred/parse-json-fn))))
+  (ExtractKeyFn. (comp doc-key-fn charred/read-json)))
 
 (def ^:no-doc write-es-schema
   (merge


### PR DESCRIPTION
Writing data to Elasticsearch, using the `id-fn` option triggers an exception on an unserializable function from the Charred library. Datasplash code to extract the document id uses an anonymous function which cannot be serialized.

Clojure Var are serializable by default. The fix is to use a Var from the Charred library.