### PR TITLE
Bump charred and other deps to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 * bump clj to 1.12.5
 * bump slf4j-pi to 2.0.18
+* bump charred to 1.039
 
 ### Fixed
 * ES unserializable function when parsing JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Added
 
 ### Changed
+* bump clj to 1.12.5
+* bump slf4j-pi to 2.0.18
 
 ### Fixed
+* ES unserializable function when parsing JSON.
 
 
 ## [0.7.34] - 2026-04-13

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/math.combinatorics "0.3.2"]
                  [org.clojure/tools.logging "1.3.1"]
 
-                 [com.cnuernber/charred "1.038"]
+                 [com.cnuernber/charred "1.039"]
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
 

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ngrunwald/datasplash"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.12.4"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
                  [org.clojure/math.combinatorics "0.3.2"]
                  [org.clojure/tools.logging "1.3.1"]
 
@@ -30,7 +30,7 @@
 
                  ;; as of 2.64.0, beam is now compatibla with slf4j 2.x. See
                  ;; https://github.com/apache/beam/pull/33574
-                 [org.slf4j/slf4j-api "2.0.17"]]
+                 [org.slf4j/slf4j-api "2.0.18"]]
   :pedantic? false
   :target-path "target/%s/"
   :source-paths ["src/clj"]
@@ -41,12 +41,12 @@
                    [[com.oscaro/tools-io "0.3.43"]
                     ;; include compression libs for tests
                     ;;  zstd
-                    [com.github.luben/zstd-jni "1.5.7-7"]
+                    [com.github.luben/zstd-jni "1.5.7-11"]
                     ;;  lzo & lzop
                     [io.airlift/aircompressor "2.0.3"]
                     [com.facebook.presto.hadoop/hadoop-apache2 "3.2.0-1"]
                     ;; compatible log implementation for local runs
-                    [org.slf4j/slf4j-simple "2.0.17"]]
+                    [org.slf4j/slf4j-simple "2.0.18"]]
                    :plugins [[dev.weavejester/lein-cljfmt "0.16.3"]]}
              :test {:source-paths ["test"]
                     :aot :all}})


### PR DESCRIPTION
* bump clj to 1.12.5
* bump slf4j-pi to 2.0.18
* bump charred to 1.039
~~* bump beam to 2.74.0~~

cc @kawas44 