### PR TITLE
build: bump beam (2.73.0)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,12 +13,12 @@
 
                  [com.taoensso/nippy "3.6.2"]
 
-                 [org.apache.beam/beam-sdks-java-core "2.72.0"]
-                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.72.0"]
-                 [org.apache.beam/beam-sdks-java-io-kafka "2.72.0"]
-                 [org.apache.beam/beam-runners-direct-java "2.72.0"]
-                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.72.0"]
-                 [org.apache.beam/beam-runners-core-java "2.72.0"]
+                 [org.apache.beam/beam-sdks-java-core "2.73.0"]
+                 [org.apache.beam/beam-sdks-java-io-elasticsearch "2.73.0"]
+                 [org.apache.beam/beam-sdks-java-io-kafka "2.73.0"]
+                 [org.apache.beam/beam-runners-direct-java "2.73.0"]
+                 [org.apache.beam/beam-runners-google-cloud-dataflow-java "2.73.0"]
+                 [org.apache.beam/beam-runners-core-java "2.73.0"]
                  ;; org.apache.kafka/kafka-clients is required it in
                  ;; the kafka ns. Match the version provided by beam. See:
                  ;; https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-kafka


### PR DESCRIPTION
Final version of Beam that supports Java 8.