### PR TITLE
Bump deps

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -29,7 +29,11 @@ jobs:
         cli: 1.11.4.1474
         lein: 2.12.0
         cljfmt: latest
-          
+
+    - name: Extract BEAM dep version
+      shell: bash
+      run: echo "BEAM_SDK_VERSION=$(grep org.apache.beam/beam-sdks-java-core project.clj | awk -F '\"' '{print $2;}')" >> $GITHUB_ENV
+
     # Optional step:
     - name: Cache clojure dependencies
       uses: actions/cache@v5
@@ -39,9 +43,9 @@ jobs:
           ~/.gitlibs
           ~/.deps.clj
         # List all files containing dependencies:
-        key: cljdeps-${{ hashFiles('project.clj') }}
+        key: cljdeps-${{ github.event.repository.name }}-${{ env.BEAM_SDK_VERSION }}
         restore-keys: cljdeps-
-          
+
     - name: Lint
       run: lein cljfmt check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+* bump charred to 1.041.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 * bump charred to 1.041.
+* bump nippy to 3.8.0.
 
 ### Fixed
 

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
 
-                 [com.taoensso/nippy "3.6.2"]
+                 [com.taoensso/nippy "3.8.0"]
 
                  [org.apache.beam/beam-sdks-java-core "2.74.0"]
                  [org.apache.beam/beam-sdks-java-io-elasticsearch "2.74.0"]

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
   :target-path "target/%s/"
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
-  :javac-options ["-target" "11" "-source" "11" "-Xlint:unchecked"]
+  :javac-options ["--release" "11" "-Xlint:unchecked"]
   :deploy-repositories {"releases" {:url "https://repo.clojars.org"}}
   :profiles {:dev {:dependencies
                    [[com.oscaro/tools-io "0.3.43"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/math.combinatorics "0.3.2"]
                  [org.clojure/tools.logging "1.3.1"]
 
-                 [com.cnuernber/charred "1.039"]
+                 [com.cnuernber/charred "1.041"]
                  [clj-stacktrace "0.2.8"]
                  [clj-time "0.15.2"]
 


### PR DESCRIPTION
@kawas44 @m-faucon 

* bumped charred to 1.041
* bumped nippy to 3.8.0
* resolved `javac` warning from using `-source` / `-target` by replacing them with `--release` (available since j9)
* switched actions cache key to use repo_name-BEAM_SDK_VERSION to avoid flushing cache any time project.clj was touched.

What do you think?
